### PR TITLE
Handle RabbitMQ reconnect and message resending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1396,11 +1396,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1724,14 +1719,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "rules-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rules-js/-/rules-js-1.0.0.tgz",
-      "integrity": "sha512-bm6FhqV31uwd9RViTiL+Lex2VKJ0yrDljyU7+u/oa8GhRIfQ2/y2Eez5vuMbd4oHkoJBoRIGngSJ4v4fsLTKiQ==",
-      "requires": {
-        "moment": "~2.24.0"
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,11 +55,18 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/amqp-connection-manager": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/amqp-connection-manager/-/amqp-connection-manager-2.0.10.tgz",
+      "integrity": "sha512-TW97yNQ71pFKm4kUVXRmpeeM5OU9IpnFfuBF/+Ws2sFsVc8QxUeO4mHrP2gbWcKXBcpLODViGJNomo8WUU4/Rg==",
+      "requires": {
+        "@types/amqplib": "*"
+      }
+    },
     "@types/amqplib": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.13.tgz",
       "integrity": "sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==",
-      "dev": true,
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -68,8 +75,7 @@
     "@types/bluebird": {
       "version": "3.5.29",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
-      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
-      "dev": true
+      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
     },
     "@types/chai": {
       "version": "4.2.7",
@@ -98,8 +104,7 @@
     "@types/node": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
-      "dev": true
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/simple-mock": {
       "version": "0.8.1",
@@ -128,6 +133,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "amqp-connection-manager": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/amqp-connection-manager/-/amqp-connection-manager-3.2.1.tgz",
+      "integrity": "sha512-dDs2hg8MEtuYlXMzIqWwFx4N5Fjm8vXAQNyukDavyrYsgnQVt+rtJ+oosMP7eOXukSdquCoVqOaWr/Ih6txwTA==",
+      "requires": {
+        "promise-breaker": "^5.0.0"
+      }
     },
     "amqplib": {
       "version": "0.5.5",
@@ -1587,6 +1600,11 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
+    },
+    "promise-breaker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-5.0.0.tgz",
+      "integrity": "sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA=="
     },
     "pstree.remy": {
       "version": "1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/amqp-connection-manager/-/amqp-connection-manager-2.0.10.tgz",
       "integrity": "sha512-TW97yNQ71pFKm4kUVXRmpeeM5OU9IpnFfuBF/+Ws2sFsVc8QxUeO4mHrP2gbWcKXBcpLODViGJNomo8WUU4/Rg==",
+      "dev": true,
       "requires": {
         "@types/amqplib": "*"
       }
@@ -67,6 +68,7 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.13.tgz",
       "integrity": "sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==",
+      "dev": true,
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -75,7 +77,8 @@
     "@types/bluebird": {
       "version": "3.5.29",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
-      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
+      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.2.7",
@@ -104,7 +107,8 @@
     "@types/node": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
+      "dev": true
     },
     "@types/simple-mock": {
       "version": "0.8.1",
@@ -143,9 +147,9 @@
       }
     },
     "amqplib": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.5.tgz",
-      "integrity": "sha512-sWx1hbfHbyKMw6bXOK2k6+lHL8TESWxjAx5hG8fBtT7wcxoXNIsFxZMnFyBjxt3yL14vn7WqBDe5U6BGOadtLg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.6.0.tgz",
+      "integrity": "sha512-zXCh4jQ77TBZe1YtvZ1n7sUxnTjnNagpy8MVi2yc1ive239pS3iLwm4e4d5o4XZGx1BdTKQ/U0ZmaDU3c8MxYQ==",
       "requires": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.5.2",
@@ -153,13 +157,6 @@
         "readable-stream": "1.x >=1.1.9",
         "safe-buffer": "~5.1.2",
         "url-parse": "~1.4.3"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "ansi-align": {
@@ -291,11 +288,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -1627,9 +1619,9 @@
       }
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "rc": {
       "version": "1.2.8",
@@ -1720,6 +1712,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "mocha -r ts-node/register ./tests/**/*.test.ts"
   },
   "dependencies": {
+    "@types/amqp-connection-manager": "^2.0.10",
+    "amqp-connection-manager": "^3.2.1",
     "amqplib": "^0.5.5",
     "lodash": "^4.17.15",
     "log4js": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "test": "mocha -r ts-node/register ./tests/**/*.test.ts"
   },
   "dependencies": {
-    "@types/amqp-connection-manager": "^2.0.10",
     "amqp-connection-manager": "^3.2.1",
-    "amqplib": "^0.5.5",
+    "amqplib": "^0.6.0",
     "lodash": "^4.17.15",
     "log4js": "^6.1.0"
   },
   "author": "Valtech: Daniel Morris",
   "license": "MIT",
   "devDependencies": {
+    "@types/amqp-connection-manager": "^2.0.10",
     "@types/amqplib": "^0.5.13",
     "@types/chai": "^4.2.7",
     "@types/lodash": "^4.14.149",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "amqp-connection-manager": "^3.2.1",
     "amqplib": "^0.5.5",
     "lodash": "^4.17.15",
-    "log4js": "^6.1.0",
-    "rules-js": "^1.0.0"
+    "log4js": "^6.1.0"
   },
   "author": "Valtech: Daniel Morris",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -147,17 +147,15 @@ amqpCacoon.registerConsumerBatch(
 );
 ```
 
-## Amqp-connection-manager Setup function
-[TODO]
+## Dealing With Channels via ChannelWrapper
 
-## Amqp-connection-manager ChannelWrapper
-[TODO]
+This library exposes node-amqp-connection-manager's ChannelWrapper when you call either `getConsumerChannel` or `getPublishChannel`. Instead of exposing the Amqp Channel directly (which may or may not be valid depending on the network status), AmqpConnectionManager provides a ChannelWrapper class as an interface to interacting with the underlying channel. Most functions that can be performed on an AmqpLib `Channel` can be performed on the `ChannelWrapper`, including `ackAll`, `nackAll`, etc. though they are Promise-based. See [AMQPConnectionManager's documentation](https://github.com/jwalton/node-amqp-connection-manager) for more info, as well as the underlying [amqplib docs](https://www.npmjs.com/package/amqplib).
 
-## Dealing With Channels
-
-This library exposes node-amqp-connection-manager's ChannelWrapper when you call either `getConsumerChannel` or `getPublishChannel`. The channel is also exposed when registering a consumer. To learn more about that api see documentation for [amqplib](https://www.npmjs.com/package/amqplib). Just a couple thing that you should remember to do.
+Just a couple thing that you should remember to do.
 
 1. Remember to ack or nack on all messages.
 2. An alternative is to pass an option into the `registerConsumer` to not require an ack (noAck). The problem with this is that if your application is reset or errors out, you may loose the message or messages.
 
 
+## Amqp-connection-manager Setup function
+AmqpConnectionManager allows a setup function to be passed in its configuration, or added to a ChannelWrapper at any point. This function can be used with callbacks or Promises and direclty exposes the underlying AMQP channel (since we know it is valid at that point). The setup function is useful for asserting queues and performing other necessary tasks that must be completed once a valid connection to amqp is made. Again, see [AMQPConnectionManager's documentation](https://github.com/jwalton/node-amqp-connection-manager) for more details.

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,13 @@
 
 ## Overview
 
-This is a basic library to provide amqp support. This library is a wrapper around amqplib and makes amqp easier to work with.
+This is a basic library to provide amqp support. Originally, this library was a wrapper around amqplib. It has since been updated to work with [node-amqp-connection-manager](https://github.com/jwalton/node-amqp-connection-manager), which provides support for behind-the-scenes retries on network failure. Node-amqp-connection-manager guarantees receipt of published messages and provides wrappers around potentially non-persistent channels.
 
 ## Features
 
-- Simple interace around amqplib
-- Publish flow control included out of the box (Wait for drain event if we can't publish)
-- timeout if drain event does not occurs after some amount of time when channel is not ready to receive a publish
+- Simple interace around `node-amqp-manager`
+- ~Publish flow control included out of the box (Wait for drain event if we can't publish)
+- timeout if drain event does not occurs after some amount of time when channel is not ready to receive a publish~. As of 9/26, the publish on drain functionality has been removed, as `node-amqp-manager` does not support it at this time (pending a bugfix).
 - Consume single or batch of messages
 
 ## Requirements to tests
@@ -147,9 +147,15 @@ amqpCacoon.registerConsumerBatch(
 );
 ```
 
+## Amqp-connection-manager Setup function
+[TODO]
+
+## Amqp-connection-manager ChannelWrapper
+[TODO]
+
 ## Dealing With Channels
 
-This library expose amqplib channel when you call either `getConsumerChannel` or `getPublishChannel`. The channel is also exposed when registering a consumer. To learn more about that api see documentation for [amqplib](https://www.npmjs.com/package/amqplib). Just a couple thing that you should remember to do.
+This library exposes node-amqp-connection-manager's ChannelWrapper when you call either `getConsumerChannel` or `getPublishChannel`. The channel is also exposed when registering a consumer. To learn more about that api see documentation for [amqplib](https://www.npmjs.com/package/amqplib). Just a couple thing that you should remember to do.
 
 1. Remember to ack or nack on all messages.
 2. An alternative is to pass an option into the `registerConsumer` to not require an ack (noAck). The problem with this is that if your application is reset or errors out, you may loose the message or messages.

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This is a basic library to provide amqp support. Originally, this library was a 
 ## Features
 
 - Simple interace around `node-amqp-manager`
-- ~Publish flow control included out of the box (Wait for drain event if we can't publish)
+- ~~Publish flow control included out of the box (Wait for drain event if we can't publish)~~
 - timeout if drain event does not occurs after some amount of time when channel is not ready to receive a publish~. As of 9/26, the publish on drain functionality has been removed, as `node-amqp-manager` does not support it at this time (pending a bugfix).
 - Consume single or batch of messages
 

--- a/src/helpers/message_batching_manager.ts
+++ b/src/helpers/message_batching_manager.ts
@@ -1,5 +1,5 @@
-import { ChannelWrapper, ConsumeMessage, ConsumeBatchMessages } from '../index';
-import { Logger } from 'log4js';
+import {ChannelWrapper, ConsumeMessage, ConsumeBatchMessages} from '../index';
+import {Logger} from 'log4js';
 
 export interface IMessageBatchingManagerConfig {
   providers: {
@@ -16,6 +16,7 @@ export default class MessageBatchingManager {
   private timerHandle?: NodeJS.Timeout;
   private amqpChannel?: ChannelWrapper;
   private logger?: Logger;
+
   constructor(private config: IMessageBatchingManagerConfig) {
     this.logger = config.providers.logger;
 
@@ -73,7 +74,7 @@ export default class MessageBatchingManager {
     // 2. Reset message list
     this.resetMessages();
 
-    return { bufferSize, unackedMessageList };
+    return {bufferSize, unackedMessageList};
   }
 
   /**
@@ -148,7 +149,7 @@ export default class MessageBatchingManager {
     let bufferSize: number;
     try {
       // 1. Finalize message buffer and fetch buffer and unackedMessageList
-      ({ bufferSize, unackedMessageList } = this.finalizeMessages());
+      ({bufferSize, unackedMessageList} = this.finalizeMessages());
 
       // 2. Send messages to handler
       let messages: ConsumeBatchMessages = {

--- a/src/helpers/message_batching_manager.ts
+++ b/src/helpers/message_batching_manager.ts
@@ -1,4 +1,4 @@
-import { Channel, ConsumeMessage, ConsumeBatchMessages } from '../index';
+import { ChannelWrapper, ConsumeMessage, ConsumeBatchMessages } from '../index';
 import { Logger } from 'log4js';
 
 export interface IMessageBatchingManagerConfig {
@@ -14,7 +14,7 @@ export default class MessageBatchingManager {
   private unackedMessageList: Array<ConsumeMessage> = [];
   private bufferSize: number = 1;
   private timerHandle?: NodeJS.Timeout;
-  private amqpChannel?: Channel;
+  private amqpChannel?: ChannelWrapper;
   private logger?: Logger;
   constructor(private config: IMessageBatchingManagerConfig) {
     this.logger = config.providers.logger;
@@ -85,7 +85,7 @@ export default class MessageBatchingManager {
    * @param channel: Channel - Channel
    * @param messageList: Array<ConsumeMessage> - Messages to be acked
    */
-  ackMessageList(channel: Channel, messageList: Array<ConsumeMessage>) {
+  ackMessageList(channel: ChannelWrapper, messageList: Array<ConsumeMessage>) {
     if (this.logger) {
       this.logger.trace(`MessageBatchingManager.ackMessageList: Start`);
     }
@@ -109,7 +109,7 @@ export default class MessageBatchingManager {
    * @param messageList: Array<ConsumeMessage> - Messages to be nacked
    */
   nackMessageList(
-    channel: Channel,
+    channel: ChannelWrapper,
     messageList: Array<ConsumeMessage>,
     requeue?: boolean
   ) {
@@ -138,8 +138,11 @@ export default class MessageBatchingManager {
    * @returns void
    */
   async sendBufferedMessages(
-    channel: Channel,
-    handler: (channel: Channel, msg: ConsumeBatchMessages) => Promise<void>
+    channel: ChannelWrapper,
+    handler: (
+      channel: ChannelWrapper,
+      msg: ConsumeBatchMessages
+    ) => Promise<void>
   ) {
     let unackedMessageList: Array<ConsumeMessage> = [];
     let bufferSize: number;
@@ -190,9 +193,12 @@ export default class MessageBatchingManager {
    * @returns void
    */
   async handleMessageBuffering(
-    channel: Channel,
+    channel: ChannelWrapper,
     msg: ConsumeMessage,
-    handler: (channel: Channel, msg: ConsumeBatchMessages) => Promise<void>
+    handler: (
+      channel: ChannelWrapper,
+      msg: ConsumeBatchMessages
+    ) => Promise<void>
   ) {
     // 1. Set channel variable for this object. This way we don't have to do an async call elswhere.
     this.amqpChannel = channel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import amqp, {
-    ChannelWrapper,
-    AmqpConnectionManager,
+  ChannelWrapper,
+  AmqpConnectionManager,
 } from 'amqp-connection-manager';
 import {ConsumeMessage, Channel, Options} from 'amqplib';
 import {Logger} from 'log4js';
@@ -15,14 +15,14 @@ const DEFAULT_MAX_BUFFER_TIME_MS = 60 * 1000; // 60 seconds
 
 // Used as return value in handler for registerConsumerBatch function
 export interface ConsumeBatchMessages {
-    batchingOptions: {
-        maxSizeBytes?: number;
-        maxTimeMs?: number;
-    };
-    totalSizeInBytes: number;
-    messages: Array<ConsumeMessage>;
-    ackAll: (allUpTo?: boolean) => void;
-    nackAll: (allUpTo?: boolean, requeue?: boolean) => void;
+  batchingOptions: {
+    maxSizeBytes?: number;
+    maxTimeMs?: number;
+  };
+  totalSizeInBytes: number;
+  messages: Array<ConsumeMessage>;
+  ackAll: (allUpTo?: boolean) => void;
+  nackAll: (allUpTo?: boolean, requeue?: boolean) => void;
 }
 
 // Used for registerConsumer function
@@ -31,27 +31,27 @@ export interface ConsumerOptions extends Options.Consume {
 
 // Used for registerConsumerBatch function
 export interface ConsumerBatchOptions extends Options.Consume {
-    batching?: {
-        maxSizeBytes?: number;
-        maxTimeMs?: number;
-    };
+  batching?: {
+    maxSizeBytes?: number;
+    maxTimeMs?: number;
+  };
 }
 
 export interface IAmqpCacoonConfig {
-    protocol?: string;
-    username?: string;
-    password?: string;
-    host?: string;
-    port?: number;
-    connectionString?: string;
-    amqp_opts: object;
-    providers: {
-        logger?: Logger;
-    };
-    onChannelConnect?: ConnectCallback;
-    onBrokerConnect?: Function;
-    onBrokerDisconnect?: Function;
-    // maxWaitForDrainMs?: number; // How long to wait for a drain event if RabbitMq fills up. Zero to wait forever. Defaults to 60000 ms (1 min)
+  protocol?: string;
+  username?: string;
+  password?: string;
+  host?: string;
+  port?: number;
+  connectionString?: string;
+  amqp_opts: object;
+  providers: {
+    logger?: Logger;
+  };
+  onChannelConnect?: ConnectCallback;
+  onBrokerConnect?: Function;
+  onBrokerDisconnect?: Function;
+  // maxWaitForDrainMs?: number; // How long to wait for a drain event if RabbitMq fills up. Zero to wait forever. Defaults to 60000 ms (1 min)
 }
 
 /**
@@ -64,368 +64,368 @@ export interface IAmqpCacoonConfig {
  * 4. When consuming the callback registered in the previous step will be called when a message is received
  **/
 class AmqpCacoon {
-    private pubChannelWrapper: ChannelWrapper | null;
-    private subChannelWrapper: ChannelWrapper | null;
-    private connection?: AmqpConnectionManager;
-    private fullHostName: string;
-    private amqp_opts: object;
-    private logger?: Logger;
-    // private maxWaitForDrainMs: number;
-    private onChannelConnect: ConnectCallback | null;
-    private onBrokerConnect: Function | null;
-    private onBrokerDisconnect: Function | null;
+  private pubChannelWrapper: ChannelWrapper | null;
+  private subChannelWrapper: ChannelWrapper | null;
+  private connection?: AmqpConnectionManager;
+  private fullHostName: string;
+  private amqp_opts: object;
+  private logger?: Logger;
+  // private maxWaitForDrainMs: number;
+  private onChannelConnect: ConnectCallback | null;
+  private onBrokerConnect: Function | null;
+  private onBrokerDisconnect: Function | null;
 
-    /**
-     * constructor
-     *
-     * Usage
-     * This function just sets some class level variables
-     *
-     * @param config - Contains the amqp connection config and the Logger provder
-     **/
-    constructor(config: IAmqpCacoonConfig) {
-        this.pubChannelWrapper = null;
-        this.subChannelWrapper = null;
-        this.fullHostName = config.connectionString || AmqpCacoon.getFullHostName(config);
-        this.amqp_opts = config.amqp_opts;
-        this.logger = config.providers.logger;
-        // this.maxWaitForDrainMs = config.maxWaitForDrainMs || 60000; // Default to 1 min
-        this.onChannelConnect = config.onChannelConnect || null;
-        this.onBrokerConnect = config.onBrokerConnect || null;
-        this.onBrokerDisconnect = config.onBrokerDisconnect || null;
+  /**
+   * constructor
+   *
+   * Usage
+   * This function just sets some class level variables
+   *
+   * @param config - Contains the amqp connection config and the Logger provder
+   **/
+  constructor(config: IAmqpCacoonConfig) {
+    this.pubChannelWrapper = null;
+    this.subChannelWrapper = null;
+    this.fullHostName = config.connectionString || AmqpCacoon.getFullHostName(config);
+    this.amqp_opts = config.amqp_opts;
+    this.logger = config.providers.logger;
+    // this.maxWaitForDrainMs = config.maxWaitForDrainMs || 60000; // Default to 1 min
+    this.onChannelConnect = config.onChannelConnect || null;
+    this.onBrokerConnect = config.onBrokerConnect || null;
+    this.onBrokerDisconnect = config.onBrokerDisconnect || null;
 
 
+  }
+
+  /**
+   * getFullHostName
+   * Just generates the full connection name for amqp based on the passed in config
+   * @param config - Contains the amqp connection config
+   **/
+  private static getFullHostName(config: IAmqpCacoonConfig) {
+    var fullHostNameString =
+      config.protocol +
+      '://' +
+      config.username +
+      ':' +
+      config.password +
+      '@' +
+      config.host;
+
+    if (config.port) {
+      fullHostNameString = fullHostNameString + ':' + config.port;
     }
+    return fullHostNameString;
+  }
 
-    /**
-     * getFullHostName
-     * Just generates the full connection name for amqp based on the passed in config
-     * @param config - Contains the amqp connection config
-     **/
-    private static getFullHostName(config: IAmqpCacoonConfig) {
-        var fullHostNameString =
-            config.protocol +
-            '://' +
-            config.username +
-            ':' +
-            config.password +
-            '@' +
-            config.host;
+  private injectConnectionEvents(connection: AmqpConnectionManager) {
+    // Subscribe to onConnect / onDisconnection functions for debugging
+    connection.on('connect', () => {
+      this.handleBrokerConnect();
+    });
 
-        if (config.port) {
-            fullHostNameString = fullHostNameString + ':' + config.port;
-        }
-        return fullHostNameString;
-    }
+    connection.on('disconnect', () => {
+      this.handleBrokerDisonnect();
+    });
+  }
 
-    private injectConnectionEvents(connection: AmqpConnectionManager) {
-        // Subscribe to onConnect / onDisconnection functions for debugging
-        connection.on('connect', () => {
-            this.handleBrokerConnect();
-        });
-
-        connection.on('disconnect', () => {
-            this.handleBrokerDisonnect();
-        });
-    }
-
-    /**
-     * getPublishChannel
-     * This connects to amqp and creates a channel or gets the current channel
-     * @return ChannelWrapper
-     **/
-    async getPublishChannel() {
-        try {
-            // Return the pubChannel if we are already connected
-            if (this.pubChannelWrapper) {
-                return this.pubChannelWrapper;
-            }
-            // Connect if needed
-            this.connection =
-                this.connection ||
-                (await amqp.connect([this.fullHostName], this.amqp_opts));
-
-            if (this.connection) {
-                this.injectConnectionEvents(this.connection);
-            }
-
-            // Open a channel (get reference to ChannelWrapper)
-            // Add a setup function that will be called on each connection retry
-            // This function is specified in the config
-            this
-                .pubChannelWrapper = this.connection.createChannel({
-                setup: (channel: Channel) => {
-                    if (this.onChannelConnect) {
-                        return this.onChannelConnect(channel);
-                    } else {
-                        return Promise.resolve();
-                    }
-                },
-            });
-        } catch
-            (e) {
-            if (this.logger) this.logger.error('AMQPCacoon.connect: Error: ', e);
-            throw e;
-        }
-// Return the channel
+  /**
+   * getPublishChannel
+   * This connects to amqp and creates a channel or gets the current channel
+   * @return ChannelWrapper
+   **/
+  async getPublishChannel() {
+    try {
+      // Return the pubChannel if we are already connected
+      if (this.pubChannelWrapper) {
         return this.pubChannelWrapper;
+      }
+      // Connect if needed
+      this.connection =
+        this.connection ||
+        (await amqp.connect([this.fullHostName], this.amqp_opts));
+
+      if (this.connection) {
+        this.injectConnectionEvents(this.connection);
+      }
+
+      // Open a channel (get reference to ChannelWrapper)
+      // Add a setup function that will be called on each connection retry
+      // This function is specified in the config
+      this
+        .pubChannelWrapper = this.connection.createChannel({
+        setup: (channel: Channel) => {
+          if (this.onChannelConnect) {
+            return this.onChannelConnect(channel);
+          } else {
+            return Promise.resolve();
+          }
+        },
+      });
+    } catch
+      (e) {
+      if (this.logger) this.logger.error('AMQPCacoon.connect: Error: ', e);
+      throw e;
     }
+// Return the channel
+    return this.pubChannelWrapper;
+  }
 
-    /**
-     * getConsumerChannel
-     * This connects to amqp and creates a channel or gets the current channel
-     * @return ChannelWrapper
-     **/
-    async getConsumerChannel() {
-        try {
-            // Return the subChannel if we are already connected
-            if (this.subChannelWrapper) return this.subChannelWrapper;
-            // Connect if needed
-            this.connection =
-                this.connection ||
-                (await amqp.connect([this.fullHostName], this.amqp_opts));
+  /**
+   * getConsumerChannel
+   * This connects to amqp and creates a channel or gets the current channel
+   * @return ChannelWrapper
+   **/
+  async getConsumerChannel() {
+    try {
+      // Return the subChannel if we are already connected
+      if (this.subChannelWrapper) return this.subChannelWrapper;
+      // Connect if needed
+      this.connection =
+        this.connection ||
+        (await amqp.connect([this.fullHostName], this.amqp_opts));
 
-            if (this.connection) {
-                this.injectConnectionEvents(this.connection);
-            }
+      if (this.connection) {
+        this.injectConnectionEvents(this.connection);
+      }
 
-            // Open a channel (get reference to ChannelWrapper)
-            // Add a setup function that will be called on each connection retry
-            // This function is specified in the config
-            this.subChannelWrapper = this.connection.createChannel({
-                setup: (channel: Channel) => {
-                    // `channel` here is a regular amqplib `ConfirmChannel`.
-                    // Note that `this` here is the channelWrapper instance.
-                    if (this.onChannelConnect) {
-                        return this.onChannelConnect(channel);
-                    } else {
-                        return Promise.resolve();
-                    }
-                },
-            });
-        } catch (e) {
-            if (this.logger)
-                this.logger.error('AMQPCacoon.getConsumerChannel: Error: ', e);
-            throw e;
-        }
-        // Return the channel
-        return this.subChannelWrapper;
+      // Open a channel (get reference to ChannelWrapper)
+      // Add a setup function that will be called on each connection retry
+      // This function is specified in the config
+      this.subChannelWrapper = this.connection.createChannel({
+        setup: (channel: Channel) => {
+          // `channel` here is a regular amqplib `ConfirmChannel`.
+          // Note that `this` here is the channelWrapper instance.
+          if (this.onChannelConnect) {
+            return this.onChannelConnect(channel);
+          } else {
+            return Promise.resolve();
+          }
+        },
+      });
+    } catch (e) {
+      if (this.logger)
+        this.logger.error('AMQPCacoon.getConsumerChannel: Error: ', e);
+      throw e;
     }
+    // Return the channel
+    return this.subChannelWrapper;
+  }
 
-    /**
-     * registerConsumerPrivate
-     * registerConsumer and registerConsumerBatch use this function to register consumers
-     *
-     * @param queue - Name of the queue
-     * @param consumerHandler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-     * @param options : ConsumerOptions - Used to pass in consumer options
-     * @return Promise<void>
-     **/
-    private async registerConsumerPrivate(
-        queue: string,
-        consumerHandler: (
-            channel: ChannelWrapper,
-            msg: ConsumeMessage | null
-        ) => Promise<void>,
-        options?: ConsumerOptions
-    ) {
-        try {
-            // Get consumer channel
-            const channelWrapper = await this.getConsumerChannel();
+  /**
+   * registerConsumerPrivate
+   * registerConsumer and registerConsumerBatch use this function to register consumers
+   *
+   * @param queue - Name of the queue
+   * @param consumerHandler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+   * @param options : ConsumerOptions - Used to pass in consumer options
+   * @return Promise<void>
+   **/
+  private async registerConsumerPrivate(
+    queue: string,
+    consumerHandler: (
+      channel: ChannelWrapper,
+      msg: ConsumeMessage | null
+    ) => Promise<void>,
+    options?: ConsumerOptions
+  ) {
+    try {
+      // Get consumer channel
+      const channelWrapper = await this.getConsumerChannel();
 
-            channelWrapper.addSetup((channel: Channel) => {
-                // Register a consume on the current channel
-                return channel.consume(
-                    queue,
-                    consumerHandler.bind(this, channelWrapper),
-                    options
-                );
-            });
-        } catch (e) {
-            if (this.logger)
-                this.logger.error('AMQPCacoon.registerConsumerPrivate: Error: ', e);
-            throw e;
-        }
-    }
-
-    /**
-     * registerConsumer
-     * After registering a handler on a queue that handler will
-     * get called for messages received on the specified queue
-     *
-     * @param queue - Name of the queue
-     * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-     * @param options : ConsumerOptions - Used to pass in consumer options
-     * @return Promise<void>
-     **/
-    async registerConsumer(
-        queue: string,
-        handler: (channel: ChannelWrapper, msg: ConsumeMessage) => Promise<void>,
-        options?: ConsumerOptions
-    ) {
-        return this.registerConsumerPrivate(
-            queue,
-            async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
-                if (!msg) return; // We know this will always be true but typescript requires this
-                await handler(channel, msg);
-            },
-            options
+      channelWrapper.addSetup((channel: Channel) => {
+        // Register a consume on the current channel
+        return channel.consume(
+          queue,
+          consumerHandler.bind(this, channelWrapper),
+          options
         );
+      });
+    } catch (e) {
+      if (this.logger)
+        this.logger.error('AMQPCacoon.registerConsumerPrivate: Error: ', e);
+      throw e;
+    }
+  }
+
+  /**
+   * registerConsumer
+   * After registering a handler on a queue that handler will
+   * get called for messages received on the specified queue
+   *
+   * @param queue - Name of the queue
+   * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+   * @param options : ConsumerOptions - Used to pass in consumer options
+   * @return Promise<void>
+   **/
+  async registerConsumer(
+    queue: string,
+    handler: (channel: ChannelWrapper, msg: ConsumeMessage) => Promise<void>,
+    options?: ConsumerOptions
+  ) {
+    return this.registerConsumerPrivate(
+      queue,
+      async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
+        if (!msg) return; // We know this will always be true but typescript requires this
+        await handler(channel, msg);
+      },
+      options
+    );
+  }
+
+  /**
+   * registerConsumerBatch
+   * This is very similar to registerConsumer except this enables message batching.
+   * The following options are configurable
+   * 1. batching.maxTimeMs - Max time in milliseconds before we return the batch
+   * 2. batching.maxSizeBytes - Max size in bytes before we return
+   *
+   * @param queue - Name of the queue
+   * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+   * @param options : ConsumerOptions - Used to pass in consumer options
+   * @return Promise<void>
+   **/
+  async registerConsumerBatch(
+    queue: string,
+    handler: (
+      channel: ChannelWrapper,
+      msg: ConsumeBatchMessages
+    ) => Promise<void>,
+    options?: ConsumerBatchOptions
+  ) {
+    // Set some default options
+    if (!options?.batching) {
+      options = Object.assign(
+        {},
+        {
+          batching: {
+            maxTimeMs: DEFAULT_MAX_BUFFER_TIME_MS,
+            maxSizeBytes: DEFAULT_MAX_FILES_SIZE_BYTES,
+          },
+        },
+        options
+      );
     }
 
-    /**
-     * registerConsumerBatch
-     * This is very similar to registerConsumer except this enables message batching.
-     * The following options are configurable
-     * 1. batching.maxTimeMs - Max time in milliseconds before we return the batch
-     * 2. batching.maxSizeBytes - Max size in bytes before we return
-     *
-     * @param queue - Name of the queue
-     * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-     * @param options : ConsumerOptions - Used to pass in consumer options
-     * @return Promise<void>
-     **/
-    async registerConsumerBatch(
-        queue: string,
-        handler: (
-            channel: ChannelWrapper,
-            msg: ConsumeBatchMessages
-        ) => Promise<void>,
-        options?: ConsumerBatchOptions
-    ) {
-        // Set some default options
-        if (!options?.batching) {
-            options = Object.assign(
-                {},
-                {
-                    batching: {
-                        maxTimeMs: DEFAULT_MAX_BUFFER_TIME_MS,
-                        maxSizeBytes: DEFAULT_MAX_FILES_SIZE_BYTES,
-                    },
-                },
-                options
-            );
-        }
+    // Initialize Message batching manager
+    let messageBatchingHandler: MessageBatchingManager;
+    messageBatchingHandler = new MessageBatchingManager({
+      providers: {logger: this.logger},
+      maxSizeBytes: options?.batching?.maxSizeBytes,
+      maxTimeMs: options?.batching?.maxTimeMs,
+      skipNackOnFail: options?.noAck,
+    });
 
-        // Initialize Message batching manager
-        let messageBatchingHandler: MessageBatchingManager;
-        messageBatchingHandler = new MessageBatchingManager({
-            providers: {logger: this.logger},
-            maxSizeBytes: options?.batching?.maxSizeBytes,
-            maxTimeMs: options?.batching?.maxTimeMs,
-            skipNackOnFail: options?.noAck,
-        });
+    // Register consumer
+    return this.registerConsumerPrivate(
+      queue,
+      async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
+        if (!msg) return; // We know this will always be true but typescript requires this
 
-        // Register consumer
-        return this.registerConsumerPrivate(
-            queue,
-            async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
-                if (!msg) return; // We know this will always be true but typescript requires this
+        // Handle message batching
+        messageBatchingHandler.handleMessageBuffering(channel, msg, handler);
+      },
+      options
+    );
+  }
 
-                // Handle message batching
-                messageBatchingHandler.handleMessageBuffering(channel, msg, handler);
-            },
-            options
-        );
+  /**
+   * publish
+   * publish to an exchange
+   *
+   * @param exchange - name of the echange
+   * @param routingKey - queue or queue routingKey
+   * @param msgBuffer - Message buffer
+   * @param options - Options for publishing
+   * @return Promise<void> - Promise resolves when done sending
+   **/
+  async publish(
+    exchange: any,
+    routingKey: any,
+    msgBuffer: any,
+    options?: Options.Publish
+  ) {
+    try {
+      // Actually returns a wrapper
+      const channel = await this.getPublishChannel(); // Sets up the publisher channel
+
+      // TODO: Alex: Does the guaranteed publish eliminate the need to handle drain events?
+      // There's currently a reported bug in node-amqp-connection-manager saying the lib does
+      // not handle drain events properly...we should fix this.
+      await channel.publish(
+        exchange,
+        routingKey,
+        msgBuffer,
+        options
+      );
+      return;
+
+    } catch (e) {
+      if (this.logger) this.logger.error('AMQPCacoon.publish: Error: ', e);
+      throw e;
     }
+  }
 
-    /**
-     * publish
-     * publish to an exchange
-     *
-     * @param exchange - name of the echange
-     * @param routingKey - queue or queue routingKey
-     * @param msgBuffer - Message buffer
-     * @param options - Options for publishing
-     * @return Promise<void> - Promise resolves when done sending
-     **/
-    async publish(
-        exchange: any,
-        routingKey: any,
-        msgBuffer: any,
-        options?: Options.Publish
-    ) {
-        try {
-            // Actually returns a wrapper
-            const channel = await this.getPublishChannel(); // Sets up the publisher channel
+  async close() {
 
-            // TODO: Alex: Does the guaranteed publish eliminate the need to handle drain events?
-            // There's currently a reported bug in node-amqp-connection-manager saying the lib does
-            // not handle drain events properly...we should fix this.
-            await channel.publish(
-                exchange,
-                routingKey,
-                msgBuffer,
-                options
-            );
-            return;
-
-        } catch (e) {
-            if (this.logger) this.logger.error('AMQPCacoon.publish: Error: ', e);
-            throw e;
-        }
+    try {
+      await this.closePublishChannel();
+      await this.closeConsumerChannel();
+      if (this.connection) {
+        return this.connection.close();
+      }
+    } catch (error) {
+      // Some unsent messages
     }
+  }
 
-    async close() {
+  /**
+   * closeConsumerChannel
+   * Close consume channel
+   * @return Promise<void>
+   **/
+  async closeConsumerChannel() {
+    if (!this.subChannelWrapper) return;
+    await this.subChannelWrapper.close();
+    this.subChannelWrapper = null;
+    return;
+  }
 
-        try {
-            await this.closePublishChannel();
-            await this.closeConsumerChannel();
-            if (this.connection) {
-                return this.connection.close();
-            }
-        } catch (error) {
-            // Some unsent messages
-        }
+  /**
+   * closePublishChannel
+   * Close publish channel
+   * @return Promise<void>
+   **/
+  async closePublishChannel() {
+    if (!this.pubChannelWrapper) return;
+    await this.pubChannelWrapper.close();
+    this.pubChannelWrapper = null;
+    return;
+  }
+
+  /**
+   * handleBrokerConnect
+   * Fires onBrokerConnect callback function whenever amqp connection is made
+   *
+   * @return void
+   **/
+  private handleBrokerConnect() {
+    if (this.onBrokerConnect) {
+      this.onBrokerConnect();
     }
+  }
 
-    /**
-     * closeConsumerChannel
-     * Close consume channel
-     * @return Promise<void>
-     **/
-    async closeConsumerChannel() {
-        if (!this.subChannelWrapper) return;
-        await this.subChannelWrapper.close();
-        this.subChannelWrapper = null;
-        return;
+  /**
+   * handleBrokerDisconnect
+   * Fires onBrokerDisconnect callback function whenever amqp connection is lost
+   *
+   * @return void
+   **/
+  private handleBrokerDisonnect() {
+    if (this.onBrokerDisconnect) {
+      this.onBrokerDisconnect();
     }
-
-    /**
-     * closePublishChannel
-     * Close publish channel
-     * @return Promise<void>
-     **/
-    async closePublishChannel() {
-        if (!this.pubChannelWrapper) return;
-        await this.pubChannelWrapper.close();
-        this.pubChannelWrapper = null;
-        return;
-    }
-
-    /**
-     * handleBrokerConnect
-     * Fires onBrokerConnect callback function whenever amqp connection is made
-     *
-     * @return void
-     **/
-    private handleBrokerConnect() {
-        if (this.onBrokerConnect) {
-            this.onBrokerConnect();
-        }
-    }
-
-    /**
-     * handleBrokerDisconnect
-     * Fires onBrokerDisconnect callback function whenever amqp connection is lost
-     *
-     * @return void
-     **/
-    private handleBrokerDisonnect() {
-        if (this.onBrokerDisconnect) {
-            this.onBrokerDisconnect();
-        }
-    }
+  }
 }
 
 export default AmqpCacoon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,8 @@ export interface IAmqpCacoonConfig {
     logger?: Logger;
   };
   onChannelConnect?: ConnectCallback;
-  onBrokerConnect?: Function;
-  onBrokerDisconnect?: Function;
+  onBrokerConnect?: () => void;
+  onBrokerDisconnect?: () => void;
   // maxWaitForDrainMs?: number; // How long to wait for a drain event if RabbitMq fills up. Zero to wait forever. Defaults to 60000 ms (1 min)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,54 +1,55 @@
 import amqp, {
-  ChannelWrapper,
-  AmqpConnectionManager,
+    ChannelWrapper,
+    AmqpConnectionManager,
 } from 'amqp-connection-manager';
-import { ConsumeMessage, Connection, Channel, Options } from 'amqplib';
-import { Logger } from 'log4js';
+import {ConsumeMessage, Connection, Channel, Options} from 'amqplib';
+import {Logger} from 'log4js';
 import MessageBatchingManager from './helpers/message_batching_manager';
 
 type ConnectCallback = (channel: Channel) => Promise<any>;
 
-export { ConsumeMessage, ChannelWrapper, Channel, ConnectCallback };
+export {ConsumeMessage, ChannelWrapper, Channel, ConnectCallback};
 
 const DEFAULT_MAX_FILES_SIZE_BYTES = 1024 * 1024 * 2; // 2 MB
 const DEFAULT_MAX_BUFFER_TIME_MS = 60 * 1000; // 60 seconds
 
 // Used as return value in handler for registerConsumerBatch function
 export interface ConsumeBatchMessages {
-  batchingOptions: {
-    maxSizeBytes?: number;
-    maxTimeMs?: number;
-  };
-  totalSizeInBytes: number;
-  messages: Array<ConsumeMessage>;
-  ackAll: (allUpTo?: boolean) => void;
-  nackAll: (allUpTo?: boolean, requeue?: boolean) => void;
+    batchingOptions: {
+        maxSizeBytes?: number;
+        maxTimeMs?: number;
+    };
+    totalSizeInBytes: number;
+    messages: Array<ConsumeMessage>;
+    ackAll: (allUpTo?: boolean) => void;
+    nackAll: (allUpTo?: boolean, requeue?: boolean) => void;
 }
 
 // Used for registerConsumer function
-export interface ConsumerOptions extends Options.Consume {}
+export interface ConsumerOptions extends Options.Consume {
+}
 
 // Used for registerConsumerBatch function
 export interface ConsumerBatchOptions extends Options.Consume {
-  batching?: {
-    maxSizeBytes?: number;
-    maxTimeMs?: number;
-  };
+    batching?: {
+        maxSizeBytes?: number;
+        maxTimeMs?: number;
+    };
 }
 
 export interface IAmqpCacoonConfig {
-  protocol?: string;
-  username?: string;
-  password?: string;
-  host?: string;
-  port?: number;
-  connectionString?: string;
-  amqp_opts: object;
-  providers: {
-    logger?: Logger;
-  };
-  onConnect?: ConnectCallback; // TODO: This should expect a function signature with a Channel param
-  maxWaitForDrainMs?: number; // How long to wait for a drain event if RabbitMq fills up. Zero to wait forever. Defaults to 60000 ms (1 min)
+    protocol?: string;
+    username?: string;
+    password?: string;
+    host?: string;
+    port?: number;
+    connectionString?: string;
+    amqp_opts: object;
+    providers: {
+        logger?: Logger;
+    };
+    onConnect?: ConnectCallback;
+    // maxWaitForDrainMs?: number; // How long to wait for a drain event if RabbitMq fills up. Zero to wait forever. Defaults to 60000 ms (1 min)
 }
 
 /**
@@ -57,380 +58,321 @@ export interface IAmqpCacoonConfig {
  * Usage
  * 1. Instantiate and pass in the configuration using the IAmqpCacoonConfig interface
  * 2. Call publish() function to publish a message
- * 3. To consume messages call registerConsumer() passing in a handler funciton
+ * 3. To consume messages call registerConsumer() passing in a handler function
  * 4. When consuming the callback registered in the previous step will be called when a message is received
  **/
 class AmqpCacoon {
-  private pubChannelWrapper: ChannelWrapper | null;
-  private subChannelWrapper: ChannelWrapper | null;
-  private connection?: AmqpConnectionManager;
-  private fullHostName: string;
-  private amqp_opts: object;
-  private logger?: Logger;
-  private maxWaitForDrainMs: number;
-  private onConnect: ConnectCallback | null;
+    private pubChannelWrapper: ChannelWrapper | null;
+    private subChannelWrapper: ChannelWrapper | null;
+    private connection?: AmqpConnectionManager;
+    private fullHostName: string;
+    private amqp_opts: object;
+    private logger?: Logger;
+    // private maxWaitForDrainMs: number;
+    private onConnect: ConnectCallback | null;
 
-  /**
-   * constructor
-   *
-   * Usage
-   * This function just sets some class level variables
-   *
-   * @param config - Contains the amqp connection config and the Logger provder
-   **/
-  constructor(config: IAmqpCacoonConfig) {
-    this.pubChannelWrapper = null;
-    this.subChannelWrapper = null;
-    this.fullHostName = config.connectionString || this.getFullHostName(config);
-    this.amqp_opts = config.amqp_opts;
-    this.logger = config.providers.logger;
-    this.maxWaitForDrainMs = config.maxWaitForDrainMs || 60000; // Default to 1 min
-    this.onConnect = config.onConnect || null;
-  }
-
-  /**
-   * getFullHostName
-   * Just generates the full connection name for amqp based on the passed in config
-   * @param config - Contains the amqp connection config
-   **/
-  private getFullHostName(config: IAmqpCacoonConfig) {
-    var fullHostNameString =
-      config.protocol +
-      '://' +
-      config.username +
-      ':' +
-      config.password +
-      '@' +
-      config.host;
-
-    if (config.port) {
-      fullHostNameString = fullHostNameString + ':' + config.port;
+    /**
+     * constructor
+     *
+     * Usage
+     * This function just sets some class level variables
+     *
+     * @param config - Contains the amqp connection config and the Logger provder
+     **/
+    constructor(config: IAmqpCacoonConfig) {
+        this.pubChannelWrapper = null;
+        this.subChannelWrapper = null;
+        this.fullHostName = config.connectionString || AmqpCacoon.getFullHostName(config);
+        this.amqp_opts = config.amqp_opts;
+        this.logger = config.providers.logger;
+        // this.maxWaitForDrainMs = config.maxWaitForDrainMs || 60000; // Default to 1 min
+        this.onConnect = config.onConnect || null;
     }
 
-    return fullHostNameString;
-  }
+    /**
+     * getFullHostName
+     * Just generates the full connection name for amqp based on the passed in config
+     * @param config - Contains the amqp connection config
+     **/
+    private static getFullHostName(config: IAmqpCacoonConfig) {
+        var fullHostNameString =
+            config.protocol +
+            '://' +
+            config.username +
+            ':' +
+            config.password +
+            '@' +
+            config.host;
 
-  /**
-   * getPublishChannel
-   * This connects to amqp and creates a channel or gets the current channel
-   * @return channel
-   **/
-  async getPublishChannel() {
-    try {
-      // Return the pubChannel if we are already connected
-      if (this.pubChannelWrapper) {
+        if (config.port) {
+            fullHostNameString = fullHostNameString + ':' + config.port;
+        }
+        return fullHostNameString;
+    }
+
+    /**
+     * getPublishChannel
+     * This connects to amqp and creates a channel or gets the current channel
+     * @return ChannelWrapper
+     **/
+    async getPublishChannel() {
+        try {
+            // Return the pubChannel if we are already connected
+            if (this.pubChannelWrapper) {
+                return this.pubChannelWrapper;
+            }
+            // Connect if needed
+            this.connection =
+                this.connection ||
+                (await amqp.connect([this.fullHostName], this.amqp_opts));
+
+            // Open a channel (get reference to ChannelWrapper)
+            // Add a setup function that will be called on each connection retry
+            // This function is specified in the config
+            this.pubChannelWrapper = this.connection.createChannel({
+                setup: (channel: Channel) => {
+                    if (this.onConnect) {
+                        return this.onConnect(channel);
+                    } else {
+                        return Promise.resolve();
+                    }
+                },
+            });
+        } catch (e) {
+            if (this.logger) this.logger.error('AMQPCacoon.connect: Error: ', e);
+            throw e;
+        }
+        // Return the channel
         return this.pubChannelWrapper;
-      }
-      // Connect if needed
-      this.connection =
-        this.connection ||
-        (await amqp.connect([this.fullHostName], this.amqp_opts));
-
-      // Open a channel (get reference to ChannelWrapper)
-      // Add a setup function that will be called on each connection retry
-      // This function is specified in the config
-      this.pubChannelWrapper = this.connection.createChannel({
-        setup: (channel: Channel) => {
-          // `channel` here is a regular amqplib `ConfirmChannel`.
-          // return this.onConnect(channel);
-          if (this.onConnect) {
-            return this.onConnect(channel);
-          } else {
-            return Promise.resolve();
-          }
-        },
-      });
-    } catch (e) {
-      if (this.logger) this.logger.error('AMQPCacoon.connect: Error: ', e);
-      throw e;
     }
-    // Return the channel
-    return this.pubChannelWrapper;
-  }
 
-  /**
-   * getConsumerChannel
-   * This connects to amqp and creates a channel or gets the current channel
-   * @return channel
-   **/
-  async getConsumerChannel() {
-    try {
-      // Return the subChannel if we are already connected
-      if (this.subChannelWrapper) return this.subChannelWrapper;
-      // Connect if needed
-      this.connection =
-        this.connection ||
-        (await amqp.connect([this.fullHostName], this.amqp_opts));
+    /**
+     * getConsumerChannel
+     * This connects to amqp and creates a channel or gets the current channel
+     * @return ChannelWrapper
+     **/
+    async getConsumerChannel() {
+        try {
+            // Return the subChannel if we are already connected
+            if (this.subChannelWrapper) return this.subChannelWrapper;
+            // Connect if needed
+            this.connection =
+                this.connection ||
+                (await amqp.connect([this.fullHostName], this.amqp_opts));
 
-      // Open a channel (get reference to ChannelWrapper)
-      // Add a setup function that will be called on each connection retry
-      // This function is specified in the config
-      this.subChannelWrapper = this.connection.createChannel({
-        setup: (channel: Channel) => {
-          // `channel` here is a regular amqplib `ConfirmChannel`.
-          // Note that `this` here is the channelWrapper instance.
-          if (this.onConnect) {
-            return this.onConnect(channel);
-          } else {
-            return Promise.resolve();
-          }
-        },
-      });
-    } catch (e) {
-      if (this.logger)
-        this.logger.error('AMQPCacoon.getConsumerChannel: Error: ', e);
-      throw e;
+            // Open a channel (get reference to ChannelWrapper)
+            // Add a setup function that will be called on each connection retry
+            // This function is specified in the config
+            this.subChannelWrapper = this.connection.createChannel({
+                setup: (channel: Channel) => {
+                    // `channel` here is a regular amqplib `ConfirmChannel`.
+                    // Note that `this` here is the channelWrapper instance.
+                    if (this.onConnect) {
+                        return this.onConnect(channel);
+                    } else {
+                        return Promise.resolve();
+                    }
+                },
+            });
+        } catch (e) {
+            if (this.logger)
+                this.logger.error('AMQPCacoon.getConsumerChannel: Error: ', e);
+            throw e;
+        }
+        // Return the channel
+        return this.subChannelWrapper;
     }
-    // Return the channel
-    return this.subChannelWrapper;
-  }
 
-  /**
-   * registerConsumerPrivate
-   * registerConsumer and registerConsumerBatch use this function to register consumers
-   *
-   * @param queue - Name of the queue
-   * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-   * @param options : ConsumerOptions - Used to pass in consumer options
-   * @return Promise<void>
-   **/
-  private async registerConsumerPrivate(
-    queue: string,
-    consumerHandler: (
-      channel: ChannelWrapper,
-      msg: ConsumeMessage | null
-    ) => Promise<void>,
-    options?: ConsumerOptions
-  ) {
-    try {
-      // Get consumer channel
-      const channelWrapper = await this.getConsumerChannel();
+    /**
+     * registerConsumerPrivate
+     * registerConsumer and registerConsumerBatch use this function to register consumers
+     *
+     * @param queue - Name of the queue
+     * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+     * @param options : ConsumerOptions - Used to pass in consumer options
+     * @return Promise<void>
+     **/
+    private async registerConsumerPrivate(
+        queue: string,
+        consumerHandler: (
+            channel: ChannelWrapper,
+            msg: ConsumeMessage | null
+        ) => Promise<void>,
+        options?: ConsumerOptions
+    ) {
+        try {
+            // Get consumer channel
+            const channelWrapper = await this.getConsumerChannel();
 
-      channelWrapper.addSetup( (channel: Channel) => {
-        // Register a consume on the current channel
-        return channel.consume(
-          queue,
-          consumerHandler.bind(this, channelWrapper),
-          options
+            channelWrapper.addSetup((channel: Channel) => {
+                // Register a consume on the current channel
+                return channel.consume(
+                    queue,
+                    consumerHandler.bind(this, channelWrapper),
+                    options
+                );
+            });
+        } catch (e) {
+            if (this.logger)
+                this.logger.error('AMQPCacoon.registerConsumerPrivate: Error: ', e);
+            throw e;
+        }
+    }
+
+    /**
+     * registerConsumer
+     * After registering a handler on a queue that handler will
+     * get called for messages received on the specified queue
+     *
+     * @param queue - Name of the queue
+     * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+     * @param options : ConsumerOptions - Used to pass in consumer options
+     * @return Promise<void>
+     **/
+    async registerConsumer(
+        queue: string,
+        handler: (channel: ChannelWrapper, msg: ConsumeMessage) => Promise<void>,
+        options?: ConsumerOptions
+    ) {
+        return this.registerConsumerPrivate(
+            queue,
+            async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
+                if (!msg) return; // We know this will always be true but typescript requires this
+                await handler(channel, msg);
+            },
+            options
         );
-      });
-    } catch (e) {
-      if (this.logger)
-        this.logger.error('AMQPCacoon.registerConsumerPrivate: Error: ', e);
-      throw e;
-    }
-  }
-
-  /**
-   * registerConsumer
-   * After registering a handler on a queue that handler will
-   * get called for messages received on the specified queue
-   *
-   * @param queue - Name of the queue
-   * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-   * @param options : ConsumerOptions - Used to pass in consumer options
-   * @return Promise<void>
-   **/
-  async registerConsumer(
-    queue: string,
-    handler: (channel: ChannelWrapper, msg: ConsumeMessage) => Promise<void>,
-    options?: ConsumerOptions
-  ) {
-    return this.registerConsumerPrivate(
-      queue,
-      async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
-        if (!msg) return; // We know this will always be true but typescript requires this
-        await handler(channel, msg);
-      },
-      options
-    );
-  }
-
-  /**
-   * registerConsumerBatch
-   * This is very similar to registerConsumer except this enables message batching.
-   * The following options are configurable
-   * 1. batching.maxTimeMs - Max time in milliseconds before we return the batch
-   * 2. batching.maxSizeBytes - Max size in bytes before we return
-   *
-   * @param queue - Name of the queue
-   * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
-   * @param options : ConsumerOptions - Used to pass in consumer options
-   * @return Promise<void>
-   **/
-  async registerConsumerBatch(
-    queue: string,
-    handler: (
-      channel: ChannelWrapper,
-      msg: ConsumeBatchMessages
-    ) => Promise<void>,
-    options?: ConsumerBatchOptions
-  ) {
-    // Set some default options
-    if (!options?.batching) {
-      options = Object.assign(
-        {},
-        {
-          batching: {
-            maxTimeMs: DEFAULT_MAX_BUFFER_TIME_MS,
-            maxSizeBytes: DEFAULT_MAX_FILES_SIZE_BYTES,
-          },
-        },
-        options
-      );
     }
 
-    // Initialize Message batching manager
-    let messageBatchingHandler: MessageBatchingManager;
-    messageBatchingHandler = new MessageBatchingManager({
-      providers: { logger: this.logger },
-      maxSizeBytes: options?.batching?.maxSizeBytes,
-      maxTimeMs: options?.batching?.maxTimeMs,
-      skipNackOnFail: options?.noAck,
-    });
-
-    // Register consumer
-    return this.registerConsumerPrivate(
-      queue,
-      async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
-        if (!msg) return; // We know this will always be true but typescript requires this
-
-        // Handle message batching
-        messageBatchingHandler.handleMessageBuffering(channel, msg, handler);
-      },
-      options
-    );
-  }
-
-  /**
-   * publish
-   * publish to an exchange
-   *
-   * @param exchange - name of the echange
-   * @param routingKey - queue or queue routingKey
-   * @param msgBuffer - Message buffer
-   * @param options - Options for publishing
-   * @return Promise<void> - Promise resolves when done sending
-   **/
-  async publish(
-    exchange: any,
-    routingKey: any,
-    msgBuffer: any,
-    options?: Options.Publish
-  ) {
-    try {
-      // Actually returns a wrapper
-      const channel = await this.getPublishChannel(); // Sets up the publisher channel
-
-      // We add a promise so that we can control flow
-      // Perform the channel operation and hold the result which will be true/false per AMQP Lib docs
-      const channelReady = channel.publish(
-        exchange,
-        routingKey,
-        msgBuffer,
-        options
-      );
-      if (this.logger) {
-        this.logger.trace(`AMQPCacoon.publish result: ${channelReady}`);
-      }
-      // Check the result. channelReady == true means we can keep sending, so we resolve this promise
-      if (channelReady) {
-        return;
-      } else {
-        // Otherwise, channelReady == false so we have to wait for the pubChannel's on 'drain'
-        if (this.logger) {
-          this.logger.info(
-            'AMQPCacoon.publish buffer full. Waiting for "drain"...'
-          );
+    /**
+     * registerConsumerBatch
+     * This is very similar to registerConsumer except this enables message batching.
+     * The following options are configurable
+     * 1. batching.maxTimeMs - Max time in milliseconds before we return the batch
+     * 2. batching.maxSizeBytes - Max size in bytes before we return
+     *
+     * @param queue - Name of the queue
+     * @param handler: (channel: ChannelWrapper, msg: object) => Promise<any> - A handler that receives the message
+     * @param options : ConsumerOptions - Used to pass in consumer options
+     * @return Promise<void>
+     **/
+    async registerConsumerBatch(
+        queue: string,
+        handler: (
+            channel: ChannelWrapper,
+            msg: ConsumeBatchMessages
+        ) => Promise<void>,
+        options?: ConsumerBatchOptions
+    ) {
+        // Set some default options
+        if (!options?.batching) {
+            options = Object.assign(
+                {},
+                {
+                    batching: {
+                        maxTimeMs: DEFAULT_MAX_BUFFER_TIME_MS,
+                        maxSizeBytes: DEFAULT_MAX_FILES_SIZE_BYTES,
+                    },
+                },
+                options
+            );
         }
 
-        // Set a handler for the drain event
-        await new Promise((resolve, reject) => {
-          if (!this.pubChannelWrapper) {
-            // This shouldn't ever happen
-            throw new Error(
-              `AMQPCacoon.public: Publisher channel has not been set up`
-            );
-          }
-          // Set a timeout in case Drain is slow, at least we log it
-          let timeoutHandler: any =
-            this.maxWaitForDrainMs !== 0
-              ? setTimeout(() => {
-                  if (this.logger) {
-                    this.logger.info(
-                      `AMQPCacoon.publish: After a full buffer, slow buffer: \nmsg: ${msgBuffer.toString(
-                        'utf8'
-                      )}`
-                    );
-                  }
-                  if (timeoutHandler) {
-                    timeoutHandler = null;
-                    reject(
-                      new Error(
-                        `AMQPCacoon.public: Timeout after ${this.maxWaitForDrainMs}ms`
-                      )
-                    );
-                  }
-                }, this.maxWaitForDrainMs)
-              : true;
-
-          channel.once('drain', () => {
-            if (this.logger) {
-              this.logger.trace('AMQPCacoon.publish: "drain" received.');
-            }
-            // resolve since we now can proceed
-            if (timeoutHandler) {
-              if (this.maxWaitForDrainMs !== 0) {
-                clearTimeout(timeoutHandler);
-                timeoutHandler = null;
-              }
-              resolve();
-            }
-          });
+        // Initialize Message batching manager
+        let messageBatchingHandler: MessageBatchingManager;
+        messageBatchingHandler = new MessageBatchingManager({
+            providers: {logger: this.logger},
+            maxSizeBytes: options?.batching?.maxSizeBytes,
+            maxTimeMs: options?.batching?.maxTimeMs,
+            skipNackOnFail: options?.noAck,
         });
-      }
-    } catch (e) {
-      if (this.logger) this.logger.error('AMQPCacoon.publish: Error: ', e);
-      throw e;
+
+        // Register consumer
+        return this.registerConsumerPrivate(
+            queue,
+            async (channel: ChannelWrapper, msg: ConsumeMessage | null) => {
+                if (!msg) return; // We know this will always be true but typescript requires this
+
+                // Handle message batching
+                messageBatchingHandler.handleMessageBuffering(channel, msg, handler);
+            },
+            options
+        );
     }
-  }
 
-  async close() {
+    /**
+     * publish
+     * publish to an exchange
+     *
+     * @param exchange - name of the echange
+     * @param routingKey - queue or queue routingKey
+     * @param msgBuffer - Message buffer
+     * @param options - Options for publishing
+     * @return Promise<void> - Promise resolves when done sending
+     **/
+    async publish(
+        exchange: any,
+        routingKey: any,
+        msgBuffer: any,
+        options?: Options.Publish
+    ) {
+        try {
+            // Actually returns a wrapper
+            const channel = await this.getPublishChannel(); // Sets up the publisher channel
 
-    try {
-      await this.closePublishChannel();
-      await this.closeConsumerChannel();
-      if (this.connection) {
-        return this.connection.close();
-      }
-    } catch (error) {
-      // Some unsent messages
+            // TODO: Alex: Does the guaranteed publish eliminate the need to handle drain events?
+            // There's currently a reported bug in node-amqp-connection-manager saying the lib does
+            // not handle drain events properly...we should fix this.
+            await channel.publish(
+                exchange,
+                routingKey,
+                msgBuffer,
+                options
+            );
+            return;
+
+        } catch (e) {
+            if (this.logger) this.logger.error('AMQPCacoon.publish: Error: ', e);
+            throw e;
+        }
     }
-  }
 
-  /**
-   * closeConsumerChannel
-   * Close consume channel
-   * @return Promise<void>
-   **/
-  async closeConsumerChannel() {
-    if (!this.subChannelWrapper) return;
-    await this.subChannelWrapper.close();
-    this.subChannelWrapper = null;
-    return;
-  }
+    async close() {
 
-  /**
-   * closePublishChannel
-   * Close publish channel
-   * @return Promise<void>
-   **/
-  async closePublishChannel() {
-    if (!this.pubChannelWrapper) return;
-    await this.pubChannelWrapper.close();
-    this.pubChannelWrapper = null;
-    return;
-  }
+        try {
+            await this.closePublishChannel();
+            await this.closeConsumerChannel();
+            if (this.connection) {
+                return this.connection.close();
+            }
+        } catch (error) {
+            // Some unsent messages
+        }
+    }
+
+    /**
+     * closeConsumerChannel
+     * Close consume channel
+     * @return Promise<void>
+     **/
+    async closeConsumerChannel() {
+        if (!this.subChannelWrapper) return;
+        await this.subChannelWrapper.close();
+        this.subChannelWrapper = null;
+        return;
+    }
+
+    /**
+     * closePublishChannel
+     * Close publish channel
+     * @return Promise<void>
+     **/
+    async closePublishChannel() {
+        if (!this.pubChannelWrapper) return;
+        await this.pubChannelWrapper.close();
+        this.pubChannelWrapper = null;
+        return;
+    }
 }
 
 export default AmqpCacoon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,8 +142,7 @@ class AmqpCacoon {
       }
       // Connect if needed
       this.connection =
-        this.connection ||
-        (await amqp.connect([this.fullHostName], this.amqp_opts));
+        this.connection || amqp.connect([this.fullHostName], this.amqp_opts);
 
       if (this.connection) {
         this.injectConnectionEvents(this.connection);
@@ -182,8 +181,7 @@ class AmqpCacoon {
       if (this.subChannelWrapper) return this.subChannelWrapper;
       // Connect if needed
       this.connection =
-        this.connection ||
-        (await amqp.connect([this.fullHostName], this.amqp_opts));
+        this.connection || amqp.connect([this.fullHostName], this.amqp_opts);
 
       if (this.connection) {
         this.injectConnectionEvents(this.connection);

--- a/tests/unit/amqp-cacoon.test.ts
+++ b/tests/unit/amqp-cacoon.test.ts
@@ -1,13 +1,14 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import _ from 'lodash';
 import 'mocha';
 import simple from 'simple-mock';
 import AmqpCacoon, {
-  IAmqpCacoonConfig,
-  Channel,
-  ConsumeMessage,
-  ConsumeBatchMessages,
-  ConsumerBatchOptions,
+    IAmqpCacoonConfig,
+    ChannelWrapper,
+    ConsumeMessage,
+    Channel,
+    ConsumeBatchMessages,
+    ConsumerBatchOptions,
 } from '../../src';
 
 let defaultMessageBusConfig = {
@@ -22,16 +23,16 @@ let defaultMessageBusConfig = {
   port: 5672,
 };
 const config: any = {
-  messageBus: {
-    // Queue setup
-    testQueue: 'test-queue',
-  },
+    messageBus: {
+        // Queue setup
+        testQueue: 'test-queue',
+    },
 };
 
 if (process.env.RABBITMQ_CONNECTION_STRING) {
-  config.messageBus.connectionString = process.env.RABBITMQ_CONNECTION_STRING;
+    config.messageBus.connectionString = process.env.RABBITMQ_CONNECTION_STRING;
 } else {
-  _.extend(config.messageBus, defaultMessageBusConfig);
+    _.extend(config.messageBus, defaultMessageBusConfig);
 }
 
 import log4js from 'log4js';
@@ -41,283 +42,335 @@ logger = log4js.getLogger('synchronous');
 logger.level = 'trace';
 
 describe('Amqp Cacoon', () => {
-  let amqpCacoonConfig: IAmqpCacoonConfig = {
-    protocol: config.messageBus.protocol,
-    username: config.messageBus.username,
-    password: config.messageBus.password,
-    host: config.messageBus.host,
-    port: config.messageBus.port,
-    connectionString: config.messageBus.connectionString,
-    amqp_opts: {},
-    providers: {
-      logger: logger,
-    },
-    maxWaitForDrainMs: 50,
-  };
+    let amqpCacoonConfig: IAmqpCacoonConfig = {
+        protocol: config.messageBus.protocol,
+        username: config.messageBus.username,
+        password: config.messageBus.password,
+        host: config.messageBus.host,
+        port: config.messageBus.port,
+        connectionString: config.messageBus.connectionString,
+        amqp_opts: {},
+        providers: {
+            logger: logger,
+        },
+        onConnect: async function (channel: Channel) {
+            if (channel) {
+                console.log("onConnect called");
 
-  afterEach(() => {
-    simple.restore();
-  });
-  // Just make sure it initializes
-  it('Constructor: Initializes', () => {
-    new AmqpCacoon(amqpCacoonConfig);
-  });
+                await channel.assertQueue(config.messageBus.testQueue);
+                await channel.purgeQueue(config.messageBus.testQueue);
 
-  it('getConsumerChannel() - channel is returned', async () => {
-    let amqpCacoon: any;
-    try {
-      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-      let channel: Channel | null = await amqpCacoon.getConsumerChannel();
-      expect(channel, 'Is undefined').to.not.be.undefined;
-      expect(channel, 'Is null').to.not.be.null;
-
-      if (amqpCacoon) amqpCacoon.close();
-    } catch (e) {
-      if (amqpCacoon) amqpCacoon.close();
-      throw e;
-    }
-  });
-
-  it('getPublishChannel() - channel is returned', async () => {
-    let amqpCacoon: any;
-    try {
-      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-      let channel: Channel | null = await amqpCacoon.getPublishChannel();
-      expect(channel, 'Is undefined').to.not.be.undefined;
-      expect(channel, 'Is null').to.not.be.null;
-
-      if (amqpCacoon) amqpCacoon.close();
-    } catch (e) {
-      if (amqpCacoon) amqpCacoon.close();
-      throw e;
-    }
-  });
-
-  it('publish/consume - Published message is received correctly', async () => {
-    let amqpCacoon: AmqpCacoon | null = null;
-    try {
-      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-      let channel: Channel | null = await amqpCacoon.getPublishChannel();
-      if (channel) await channel.assertQueue(config.messageBus.testQueue);
-      await channel.purgeQueue(config.messageBus.testQueue);
-
-      await new Promise(async (resolve, reject) => {
-        if (!amqpCacoon) {
-          return reject(
-            new Error('Some how amqpCacoon is null. This should not happen')
-          );
-        }
-        await amqpCacoon.publish(
-          '',
-          config.messageBus.testQueue,
-          Buffer.from('TestString')
-        );
-        let resolved = false;
-        amqpCacoon.registerConsumer(
-          config.messageBus.testQueue,
-          async (channel: Channel, msg: ConsumeMessage) => {
-            try {
-              channel.ack(msg);
-              expect(msg.content.toString(), 'Wrong message received').to.equal(
-                'TestString'
-              );
-              if (!resolved) {
-                resolve();
-                resolved = true;
-              }
-            } catch (e) {
-              reject(e);
+                console.log("done asserting, purged queue");
             }
-          }
-        );
-        setTimeout(() => {
-          if (!resolved) {
-            reject(new Error('Message rx: Timed out'));
-            resolved = true;
-          }
-        }, 200);
-      });
-      if (amqpCacoon) amqpCacoon.close();
-    } catch (e) {
-      if (amqpCacoon) amqpCacoon.close();
-      throw e;
-    }
-  });
+        },
+        maxWaitForDrainMs: 50,
+    };
 
-  it('publish - Drain timeout path', async () => {
-    let amqpCacoon: AmqpCacoon | null = null;
-    try {
-      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+    afterEach(() => {
+        simple.restore();
+    });
+    // Just make sure it initializes
+    it('Constructor: Initializes', () => {
+        new AmqpCacoon(amqpCacoonConfig);
+    });
 
-      let channelStubs = {
-        publish: simple.stub().returnWith(false),
-        once: simple.stub(),
-      };
-      let override: any = amqpCacoon;
-      override.pubChannel = channelStubs;
+    it('getConsumerChannel() - channel is returned', async () => {
+        let amqpCacoon: any;
+        try {
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+            let channel: ChannelWrapper | null = await amqpCacoon.getConsumerChannel();
+            expect(channel, 'Is undefined').to.not.be.undefined;
+            expect(channel, 'Is null').to.not.be.null;
 
-      // Test drain with timeout
-      try {
-        await amqpCacoon.publish(
-          '',
-          config.messageBus.testQueue,
-          Buffer.from('TestString')
-        );
-        throw new Error(
-          'Failed! amqpCacoon.publish should have been rejected!'
-        );
-      } catch (e) {
-        expect(e.message).to.include('Timeout');
-      }
-
-      // Test drain without timeout
-      channelStubs.once.callbackWith(null);
-      await amqpCacoon.publish(
-        '',
-        config.messageBus.testQueue,
-        Buffer.from('TestString')
-      );
-
-      expect(channelStubs.publish.called, 'channel.publish was not called').to
-        .be.true;
-
-      expect(channelStubs.once.called, 'channel.once was not called').to.be
-        .true;
-    } catch (e) {
-      throw e;
-    }
-  });
-
-  it('registerConsumerBatch - Batches on time limit', async () => {
-    try {
-      let messageStrings = ['Test1', 'Test2'];
-      await testBatchConsume(messageStrings, messageStrings, {
-        batching: { maxTimeMs: 200 },
-      });
-    } catch (e) {
-      throw e;
-    }
-  });
-
-  it('registerConsumerBatch - Batches on message size', async () => {
-    try {
-      // Doesn't get messages after going over size
-      await testBatchConsume(['Test1', 'Test2', 'Test3'], ['Test1', 'Test2'], {
-        batching: { maxTimeMs: 0, maxSizeBytes: 6 },
-      });
-
-      // Works on large messages
-      let largeMessage = '';
-      for (let i = 0; i < 1024 * 1024; i++) {
-        largeMessage += 'a';
-      }
-      await testBatchConsume(
-        [largeMessage, largeMessage, largeMessage],
-        [largeMessage, largeMessage],
-        {
-          batching: { maxTimeMs: 1000, maxSizeBytes: 1024 * 1024 * 2 },
+            if (amqpCacoon) amqpCacoon.close();
+        } catch (e) {
+            if (amqpCacoon) amqpCacoon.close();
+            throw e;
         }
-      );
-    } catch (e) {
-      throw e;
-    }
-  });
+    });
 
-  /**
-   * testBatchConsume
-   * This is used by other tests to test the registerConsumerBatch function
-   *
-   * Does this by
-   * 1. Setup amqp
-   * 2. Purge queue to make sure other tests are not messing us up
-   * 3. Publish all txMessageStrings to bus
-   * 4. Register callback with registerConsumerBatch
-   * 5. Within callback ack all if messages come through.
-   * 6. Test message length using rxMessageStrings.length
-   * 7. Test message buffer size
-   * 8. Compare rxMessageStrings values to incomming messages
-   * 9. Reject if we timeout
-   */
-  async function testBatchConsume(
-    txMessageStrings: Array<string>,
-    rxMessageStrings: Array<string>,
-    consumerOptions: ConsumerBatchOptions
-  ) {
-    let amqpCacoon: AmqpCacoon | null = null;
-    try {
-      // 1. Setup amqp
-      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-      let channel: Channel | null = await amqpCacoon.getPublishChannel();
-      if (channel) await channel.assertQueue(config.messageBus.testQueue);
-      // 2. Purge queue to make sure other tests are not messing us up
-      await channel.purgeQueue(config.messageBus.testQueue);
+    it('getPublishChannel() - channel is returned', async () => {
+        let amqpCacoon: any;
+        try {
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+            let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
+            expect(channel, 'Is undefined').to.not.be.undefined;
+            expect(channel, 'Is null').to.not.be.null;
 
-      await new Promise(async (resolve, reject) => {
-        if (!amqpCacoon) {
-          return reject(
-            new Error('Some how amqpCacoon is null. This should not happen')
-          );
+            if (amqpCacoon) amqpCacoon.close();
+        } catch (e) {
+            if (amqpCacoon) amqpCacoon.close();
+            throw e;
         }
-        // 3. Publish all txMessageStrings to bus
-        for (let msg of txMessageStrings) {
-          await amqpCacoon.publish(
-            '',
-            config.messageBus.testQueue,
-            Buffer.from(msg)
-          );
+    });
+
+    it('adds setup function', async () => {
+        let amqpCacoon: AmqpCacoon | null = null;
+
+        try {
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+            let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
+
+            expect(channel, 'Is undefined').to.not.be.undefined;
+
+            await amqpCacoon.publish(
+                '',
+                config.messageBus.testQueue,
+                Buffer.from('TestString')
+            );
+
+            //
+            if (amqpCacoon) amqpCacoon.close();
+        } catch (e) {
+            if (amqpCacoon) amqpCacoon.close();
+            throw e;
         }
+    });
 
-        let resolved = false;
-        // 4. Register callback with registerConsumerBatch
-        amqpCacoon.registerConsumerBatch(
-          config.messageBus.testQueue,
-          async (channel: Channel, batch: ConsumeBatchMessages) => {
-            try {
-              // 5. Within callback ack all if messages come through.
-              batch.ackAll();
-              // 6. Test message length using rxMessageStrings.length
-              expect(batch.messages).to.have.length;
-              expect(batch.messages.length).to.equal(rxMessageStrings.length);
-              // 7. Test message buffer size
-              expect(batch.totalSizeInBytes).to.equal(
-                rxMessageStrings // Sum length of all string in array
-                  .map((m) => m.length)
-                  .reduce((note, value) => note + value, 0)
-              );
+    it('publish/consume - Published message is received correctly', async () => {
+        let amqpCacoon: AmqpCacoon | null = null;
 
-              // 8. Compare rxMessageStrings values to incomming messages
-              for (let msg of batch.messages) {
-                expect(
-                  rxMessageStrings,
-                  'Message String did not match'
-                ).to.includes(msg.content.toString());
-              }
+        try {
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
 
-              if (!resolved) {
-                resolve();
-                resolved = true;
-              }
-            } catch (e) {
-              if (!resolved) {
-                reject(e);
-              }
+            await new Promise(async (resolve, reject) => {
+
+                    if (!amqpCacoon) {
+                        return reject(
+                            new Error('Some how amqpCacoon is null. This should not happen')
+                        );
+                    }
+
+                    console.log("finished publishing");
+                    let resolved = false;
+                    await amqpCacoon.registerConsumer(
+                        config.messageBus.testQueue,
+                        async (channel: ChannelWrapper, msg: ConsumeMessage) => {
+                            try {
+                                channel.ack(msg);
+                                expect(msg.content.toString(), 'Wrong message received').to.equal(
+                                    'TestString'
+                                );
+                                if (!resolved) {
+                                    console.log("resolved it!")
+                                    resolved = true;
+                                    resolve();
+                                }
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }
+                    );
+
+                    // Can we publish before registering consumer?
+                    await amqpCacoon.publish(
+                        '',
+                        config.messageBus.testQueue,
+                        Buffer.from('TestString')
+                    );
+
+
+
+                    setTimeout(() => {
+                        if (!resolved) {
+                            reject(new Error('Message rx: Timed out'));
+                            resolved = true;
+                        }
+                    }, 2000);
+                }
+            );
+
+            // This should happen after the promise is resolved
+
+            if (amqpCacoon) try {
+                await amqpCacoon.close();
+            } catch (error) {
+
             }
-          },
-          consumerOptions
-        );
-        // Set timer incase we timeout
-        setTimeout(() => {
-          if (!resolved) {
-            // 9. Reject if we timeout
-            reject(new Error('Message rx: Timed out'));
-            resolved = true;
-          }
-        }, (consumerOptions?.batching?.maxTimeMs || 0) + 100);
-      });
-      if (amqpCacoon) amqpCacoon.close();
-    } catch (e) {
-      if (amqpCacoon) amqpCacoon.close();
-      throw e;
+
+
+        } catch (e) {
+            if (amqpCacoon) await amqpCacoon.close();
+            throw e;
+        }
+    });
+
+    it('publish - Drain timeout path', async () => {
+        let amqpCacoon: AmqpCacoon | null = null;
+        try {
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+
+            let channelStubs = {
+                publish: simple.stub().returnWith(false),
+                once: simple.stub(),
+            };
+            let override: any = amqpCacoon;
+            override.pubChannel = channelStubs;
+
+            // Alex: I think this fails because the test is not supposed to assert the queue in this case?
+
+            // Test drain with timeout
+            try {
+                await amqpCacoon.publish(
+                    '',
+                    config.messageBus.testQueue,
+                    Buffer.from('TestString')
+                );
+                throw new Error(
+                    'Failed! amqpCacoon.publish should have been rejected!'
+                );
+            } catch (e) {
+                expect(e.message).to.include('Timeout');
+            }
+
+            // Test drain without timeout
+            channelStubs.once.callbackWith(null);
+            await amqpCacoon.publish(
+                '',
+                config.messageBus.testQueue,
+                Buffer.from('TestString')
+            );
+
+            expect(channelStubs.publish.called, 'channel.publish was not called').to
+                .be.true;
+
+            expect(channelStubs.once.called, 'channel.once was not called').to.be
+                .true;
+        } catch (e) {
+            throw e;
+        }
+    });
+
+    it('registerConsumerBatch - Batches on time limit', async () => {
+        try {
+            let messageStrings = ['Test1', 'Test2'];
+            await testBatchConsume(messageStrings, messageStrings, {
+                batching: {maxTimeMs: 200},
+            });
+        } catch (e) {
+            throw e;
+        }
+    });
+
+    it('registerConsumerBatch - Batches on message size', async () => {
+        try {
+            // Doesn't get messages after going over size
+            await testBatchConsume(['Test1', 'Test2', 'Test3'], ['Test1', 'Test2'], {
+                batching: {maxTimeMs: 0, maxSizeBytes: 6},
+            });
+
+            // Works on large messages
+            let largeMessage = '';
+            for (let i = 0; i < 1024 * 1024; i++) {
+                largeMessage += 'a';
+            }
+            await testBatchConsume(
+                [largeMessage, largeMessage, largeMessage],
+                [largeMessage, largeMessage],
+                {
+                    batching: {maxTimeMs: 1000, maxSizeBytes: 1024 * 1024 * 2},
+                }
+            );
+        } catch (e) {
+            throw e;
+        }
+    });
+
+    /**
+     * testBatchConsume
+     * This is used by other tests to test the registerConsumerBatch function
+     *
+     * Does this by
+     * 1. Setup amqp
+     * 2. Purge queue to make sure other tests are not messing us up
+     * 3. Publish all txMessageStrings to bus
+     * 4. Register callback with registerConsumerBatch
+     * 5. Within callback ack all if messages come through.
+     * 6. Test message length using rxMessageStrings.length
+     * 7. Test message buffer size
+     * 8. Compare rxMessageStrings values to incomming messages
+     * 9. Reject if we timeout
+     */
+    async function testBatchConsume(
+        txMessageStrings: Array<string>,
+        rxMessageStrings: Array<string>,
+        consumerOptions: ConsumerBatchOptions
+    ) {
+        let amqpCacoon: AmqpCacoon | null = null;
+        try {
+            // 1. Setup amqp
+            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+            let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
+            // if (channel) await channel.assertQueue(config.messageBus.testQueue);
+            // 2. Purge queue to make sure other tests are not messing us up
+            // await channel.purgeQueue(config.messageBus.testQueue);
+
+            await new Promise(async (resolve, reject) => {
+                if (!amqpCacoon) {
+                    return reject(
+                        new Error('Some how amqpCacoon is null. This should not happen')
+                    );
+                }
+                // 3. Publish all txMessageStrings to bus
+                for (let msg of txMessageStrings) {
+                    await amqpCacoon.publish(
+                        '',
+                        config.messageBus.testQueue,
+                        Buffer.from(msg)
+                    );
+                }
+
+                let resolved = false;
+                // 4. Register callback with registerConsumerBatch
+                amqpCacoon.registerConsumerBatch(
+                    config.messageBus.testQueue,
+                    async (channel: ChannelWrapper, batch: ConsumeBatchMessages) => {
+                        try {
+                            // 5. Within callback ack all if messages come through.
+                            batch.ackAll();
+                            // 6. Test message length using rxMessageStrings.length
+                            expect(batch.messages).to.have.length;
+                            expect(batch.messages.length).to.equal(rxMessageStrings.length);
+                            // 7. Test message buffer size
+                            expect(batch.totalSizeInBytes).to.equal(
+                                rxMessageStrings // Sum length of all string in array
+                                    .map((m) => m.length)
+                                    .reduce((note, value) => note + value, 0)
+                            );
+
+                            // 8. Compare rxMessageStrings values to incomming messages
+                            for (let msg of batch.messages) {
+                                expect(
+                                    rxMessageStrings,
+                                    'Message String did not match'
+                                ).to.includes(msg.content.toString());
+                            }
+
+                            if (!resolved) {
+                                resolve();
+                                resolved = true;
+                            }
+                        } catch (e) {
+                            if (!resolved) {
+                                reject(e);
+                            }
+                        }
+                    },
+                    consumerOptions
+                );
+                // Set timer incase we timeout
+                setTimeout(() => {
+                    if (!resolved) {
+                        // 9. Reject if we timeout
+                        reject(new Error('Message rx: Timed out'));
+                        resolved = true;
+                    }
+                }, (consumerOptions?.batching?.maxTimeMs || 0) + 100);
+            });
+            if (amqpCacoon) amqpCacoon.close();
+        } catch (e) {
+            if (amqpCacoon) amqpCacoon.close();
+            throw e;
+        }
     }
-  }
 });

--- a/tests/unit/amqp-cacoon.test.ts
+++ b/tests/unit/amqp-cacoon.test.ts
@@ -58,8 +58,7 @@ describe('Amqp Cacoon', () => {
                 await channel.assertQueue(config.messageBus.testQueue);
                 await channel.purgeQueue(config.messageBus.testQueue);
             }
-        },
-        maxWaitForDrainMs: 50,
+        }
     };
 
     afterEach(() => {

--- a/tests/unit/amqp-cacoon.test.ts
+++ b/tests/unit/amqp-cacoon.test.ts
@@ -3,12 +3,12 @@ import _ from 'lodash';
 import 'mocha';
 import simple from 'simple-mock';
 import AmqpCacoon, {
-    IAmqpCacoonConfig,
-    ChannelWrapper,
-    ConsumeMessage,
-    Channel,
-    ConsumeBatchMessages,
-    ConsumerBatchOptions,
+  IAmqpCacoonConfig,
+  ChannelWrapper,
+  ConsumeMessage,
+  Channel,
+  ConsumeBatchMessages,
+  ConsumerBatchOptions,
 } from '../../src';
 
 let defaultMessageBusConfig = {
@@ -23,16 +23,16 @@ let defaultMessageBusConfig = {
   port: 5672,
 };
 const config: any = {
-    messageBus: {
-        // Queue setup
-        testQueue: 'test-queue',
-    },
+  messageBus: {
+    // Queue setup
+    testQueue: 'test-queue',
+  },
 };
 
 if (process.env.RABBITMQ_CONNECTION_STRING) {
-    config.messageBus.connectionString = process.env.RABBITMQ_CONNECTION_STRING;
+  config.messageBus.connectionString = process.env.RABBITMQ_CONNECTION_STRING;
 } else {
-    _.extend(config.messageBus, defaultMessageBusConfig);
+  _.extend(config.messageBus, defaultMessageBusConfig);
 }
 
 import log4js from 'log4js';
@@ -42,396 +42,396 @@ logger = log4js.getLogger('synchronous');
 logger.level = 'trace';
 
 describe('Amqp Cacoon', () => {
-    let amqpCacoonConfig: IAmqpCacoonConfig = {
-        protocol: config.messageBus.protocol,
-        username: config.messageBus.username,
-        password: config.messageBus.password,
-        host: config.messageBus.host,
-        port: config.messageBus.port,
-        connectionString: config.messageBus.connectionString,
-        amqp_opts: {},
-        providers: {
-            logger: logger,
-        },
-        onChannelConnect: async function (channel: Channel) {
-            if (channel) {
-                await channel.assertQueue(config.messageBus.testQueue);
-                await channel.purgeQueue(config.messageBus.testQueue);
-            }
-        }
-    };
-
-    afterEach(() => {
-        simple.restore();
-    });
-    // Just make sure it initializes
-    it('Constructor: Initializes', () => {
-        new AmqpCacoon(amqpCacoonConfig);
-    });
-
-    it('getConsumerChannel() - channel is returned', async () => {
-        let amqpCacoon: any;
-        try {
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-            let channel: ChannelWrapper | null = await amqpCacoon.getConsumerChannel();
-            expect(channel, 'Is undefined').to.not.be.undefined;
-            expect(channel, 'Is null').to.not.be.null;
-
-            if (amqpCacoon) amqpCacoon.close();
-        } catch (e) {
-            if (amqpCacoon) amqpCacoon.close();
-            throw e;
-        }
-    });
-
-    it('getPublishChannel() - channel is returned', async () => {
-        let amqpCacoon: any;
-        try {
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-            let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
-            expect(channel, 'Is undefined').to.not.be.undefined;
-            expect(channel, 'Is null').to.not.be.null;
-
-            if (amqpCacoon) amqpCacoon.close();
-        } catch (e) {
-            if (amqpCacoon) amqpCacoon.close();
-            throw e;
-        }
-    });
-
-    it('publish/consume - Published message is received correctly', async () => {
-        let amqpCacoon: AmqpCacoon | null = null;
-
-        try {
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-
-            await new Promise(async (resolve, reject) => {
-                    if (!amqpCacoon) {
-                        return reject(
-                            new Error('Some how amqpCacoon is null. This should not happen')
-                        );
-                    }
-
-                    let resolved = false;
-                    await amqpCacoon.registerConsumer(
-                        config.messageBus.testQueue,
-                        async (channel: ChannelWrapper, msg: ConsumeMessage) => {
-                            try {
-                                channel.ack(msg);
-                                expect(msg.content.toString(), 'Wrong message received').to.equal(
-                                    'TestString'
-                                );
-                                if (!resolved) {
-                                    resolved = true;
-                                    resolve();
-                                }
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-
-                    // Can we publish before registering consumer?
-                    await amqpCacoon.publish(
-                        '',
-                        config.messageBus.testQueue,
-                        Buffer.from('TestString')
-                    );
-
-                    setTimeout(() => {
-                        if (!resolved) {
-                            reject(new Error('Message rx: Timed out'));
-                            resolved = true;
-                        }
-                    }, 200);
-                }
-            );
-
-            // Add short delay before closing connection
-            // For some reason, closing the channel immediately causes issues
-            const delay = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
-
-            await delay(1000).then(async () => {
-                if (amqpCacoon) {
-                    await amqpCacoon.close();
-                }
-            });
-
-        } catch (e) {
-            if (amqpCacoon) await amqpCacoon.close();
-            throw e;
-        }
-    });
-
-    // For now (until we decide to mock rmq, this is for manual testing)
-    // Start and stop rabbit mq to verify that messages sent when
-    // connection is down are received on reconnect
-    it.skip('resends messages after disconnect', async () => {
-        let amqpCacoon: AmqpCacoon | null = null;
-
-        try {
-            amqpCacoonConfig.onBrokerConnect = () => {
-                console.log("Connection made!")
-            }
-
-            amqpCacoonConfig.onBrokerDisconnect = () => {
-                console.log("Connection lost!")
-            }
-
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-
-            await new Promise(async (resolve, reject) => {
-                    if (!amqpCacoon) {
-                        return reject(
-                            new Error('Some how amqpCacoon is null. This should not happen')
-                        );
-                    }
-
-                    let resolved = false;
-                    let numConsumed = 0;
-                    let numSent = 0;
-                    let numToSend = 6;
-                    await amqpCacoon.registerConsumer(
-                        config.messageBus.testQueue,
-                        async (channel: ChannelWrapper, msg: ConsumeMessage) => {
-                            try {
-                                channel.ack(msg);
-                                console.log("Received message: ", msg.content.toString());
-                                numConsumed++;
-                                if (numToSend == numConsumed) {
-                                    resolved = true;
-                                    resolve();
-                                }
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-
-
-                    setInterval(async () => {
-                        if (amqpCacoon) {
-                            if (numSent < numToSend) {
-                                let msgContent = "Test message " + numSent;
-                                console.log("Sending message: ", msgContent);
-
-                                // Do not await successful receipt, event if connection is lost
-                                // Keep sending while connection is down
-                                amqpCacoon.publish(
-                                    '',
-                                    config.messageBus.testQueue,
-                                    Buffer.from(msgContent)
-                                );
-                                numSent++;
-
-                            } else {
-                                // Stop calling this function
-                                console.log("I guess we sent them all");
-                            }
-                        }
-
-                    }, 10000);
-
-                    setTimeout(() => {
-                        if (!resolved) {
-                            reject(new Error('Message rx: Timed out'));
-                            resolved = true;
-                        }
-                    }, 100000);
-                }
-            );
-
-            // Add short delay before closing connection
-            // For some reason, closing the channel immediately causes issues
-            const delay = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
-
-            await delay(1000).then(async () => {
-                if (amqpCacoon) {
-                    await amqpCacoon.close();
-                }
-            });
-
-        } catch (e) {
-            if (amqpCacoon) await amqpCacoon.close();
-            throw e;
-        }
-    }).timeout(100000);
-
-    // Skipping this test for now, until we confirm / deny that we will try to listen to drain event
-    it.skip('publish - Drain timeout path', async () => {
-        let amqpCacoon: AmqpCacoon | null = null;
-        try {
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-
-            let channelStubs = {
-                publish: simple.stub().returnWith(false),
-                once: simple.stub(),
-            };
-            let override: any = amqpCacoon;
-            override.pubChannel = channelStubs;
-
-            // Test drain with timeout
-            try {
-                await amqpCacoon.publish(
-                    '',
-                    config.messageBus.testQueue,
-                    Buffer.from('TestString')
-                );
-                throw new Error(
-                    'Failed! amqpCacoon.publish should have been rejected!'
-                );
-            } catch (e) {
-                console.log(e);
-                expect(e.message).to.include('Timeout');
-            }
-
-            // Test drain without timeout
-            channelStubs.once.callbackWith(null);
-            await amqpCacoon.publish(
-                '',
-                config.messageBus.testQueue,
-                Buffer.from('TestString')
-            );
-
-            expect(channelStubs.publish.called, 'channel.publish was not called').to
-                .be.true;
-            expect(channelStubs.once.called, 'channel.once was not called').to.be
-                .true;
-        } catch (e) {
-            throw e;
-        }
-    });
-
-    it('registerConsumerBatch - Batches on time limit', async () => {
-        try {
-            let messageStrings = ['Test1', 'Test2'];
-            await testBatchConsume(messageStrings, messageStrings, {
-                batching: {maxTimeMs: 200},
-            });
-        } catch (e) {
-            throw e;
-        }
-    });
-
-    it('registerConsumerBatch - Batches on message size', async () => {
-        try {
-            // Doesn't get messages after going over size
-            await testBatchConsume(['Test1', 'Test2', 'Test3'], ['Test1', 'Test2'], {
-                batching: {maxTimeMs: 0, maxSizeBytes: 6},
-            });
-
-            // Works on large messages
-            let largeMessage = '';
-            for (let i = 0; i < 1024 * 1024; i++) {
-                largeMessage += 'a';
-            }
-            await testBatchConsume(
-                [largeMessage, largeMessage, largeMessage],
-                [largeMessage, largeMessage],
-                {
-                    batching: {maxTimeMs: 1000, maxSizeBytes: 1024 * 1024 * 2},
-                }
-            );
-        } catch (e) {
-            throw e;
-        }
-    });
-
-    /**
-     * testBatchConsume
-     * This is used by other tests to test the registerConsumerBatch function
-     *
-     * Does this by
-     * 1. Setup amqp
-     * 2. Purge queue to make sure other tests are not messing us up
-     * 3. Publish all txMessageStrings to bus
-     * 4. Register callback with registerConsumerBatch
-     * 5. Within callback ack all if messages come through.
-     * 6. Test message length using rxMessageStrings.length
-     * 7. Test message buffer size
-     * 8. Compare rxMessageStrings values to incomming messages
-     * 9. Reject if we timeout
-     */
-    async function testBatchConsume(
-        txMessageStrings: Array<string>,
-        rxMessageStrings: Array<string>,
-        consumerOptions: ConsumerBatchOptions
-    ) {
-        let amqpCacoon: AmqpCacoon | null = null;
-        try {
-            // 1. Setup amqp
-            amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
-            let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
-            // if (channel) await channel.assertQueue(config.messageBus.testQueue);
-            // 2. Purge queue to make sure other tests are not messing us up
-            // await channel.purgeQueue(config.messageBus.testQueue);
-
-            await new Promise(async (resolve, reject) => {
-                if (!amqpCacoon) {
-                    return reject(
-                        new Error('Some how amqpCacoon is null. This should not happen')
-                    );
-                }
-                // 3. Publish all txMessageStrings to bus
-                for (let msg of txMessageStrings) {
-                    await amqpCacoon.publish(
-                        '',
-                        config.messageBus.testQueue,
-                        Buffer.from(msg)
-                    );
-                }
-
-                let resolved = false;
-                // 4. Register callback with registerConsumerBatch
-                amqpCacoon.registerConsumerBatch(
-                    config.messageBus.testQueue,
-                    async (channel: ChannelWrapper, batch: ConsumeBatchMessages) => {
-                        try {
-                            // 5. Within callback ack all if messages come through.
-                            batch.ackAll();
-                            // 6. Test message length using rxMessageStrings.length
-                            expect(batch.messages).to.have.length;
-                            expect(batch.messages.length).to.equal(rxMessageStrings.length);
-                            // 7. Test message buffer size
-                            expect(batch.totalSizeInBytes).to.equal(
-                                rxMessageStrings // Sum length of all string in array
-                                    .map((m) => m.length)
-                                    .reduce((note, value) => note + value, 0)
-                            );
-
-                            // 8. Compare rxMessageStrings values to incomming messages
-                            for (let msg of batch.messages) {
-                                expect(
-                                    rxMessageStrings,
-                                    'Message String did not match'
-                                ).to.includes(msg.content.toString());
-                            }
-
-                            if (!resolved) {
-                                resolve();
-                                resolved = true;
-                            }
-                        } catch (e) {
-                            if (!resolved) {
-                                reject(e);
-                            }
-                        }
-                    },
-                    consumerOptions
-                );
-                // Set timer incase we timeout
-                setTimeout(() => {
-                    if (!resolved) {
-                        // 9. Reject if we timeout
-                        reject(new Error('Message rx: Timed out'));
-                        resolved = true;
-                    }
-                }, (consumerOptions?.batching?.maxTimeMs || 0) + 100);
-            });
-            if (amqpCacoon) amqpCacoon.close();
-        } catch (e) {
-            if (amqpCacoon) amqpCacoon.close();
-            throw e;
-        }
+  let amqpCacoonConfig: IAmqpCacoonConfig = {
+    protocol: config.messageBus.protocol,
+    username: config.messageBus.username,
+    password: config.messageBus.password,
+    host: config.messageBus.host,
+    port: config.messageBus.port,
+    connectionString: config.messageBus.connectionString,
+    amqp_opts: {},
+    providers: {
+      logger: logger,
+    },
+    onChannelConnect: async function (channel: Channel) {
+      if (channel) {
+        await channel.assertQueue(config.messageBus.testQueue);
+        await channel.purgeQueue(config.messageBus.testQueue);
+      }
     }
+  };
+
+  afterEach(() => {
+    simple.restore();
+  });
+  // Just make sure it initializes
+  it('Constructor: Initializes', () => {
+    new AmqpCacoon(amqpCacoonConfig);
+  });
+
+  it('getConsumerChannel() - channel is returned', async () => {
+    let amqpCacoon: any;
+    try {
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+      let channel: ChannelWrapper | null = await amqpCacoon.getConsumerChannel();
+      expect(channel, 'Is undefined').to.not.be.undefined;
+      expect(channel, 'Is null').to.not.be.null;
+
+      if (amqpCacoon) amqpCacoon.close();
+    } catch (e) {
+      if (amqpCacoon) amqpCacoon.close();
+      throw e;
+    }
+  });
+
+  it('getPublishChannel() - channel is returned', async () => {
+    let amqpCacoon: any;
+    try {
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+      let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
+      expect(channel, 'Is undefined').to.not.be.undefined;
+      expect(channel, 'Is null').to.not.be.null;
+
+      if (amqpCacoon) amqpCacoon.close();
+    } catch (e) {
+      if (amqpCacoon) amqpCacoon.close();
+      throw e;
+    }
+  });
+
+  it('publish/consume - Published message is received correctly', async () => {
+    let amqpCacoon: AmqpCacoon | null = null;
+
+    try {
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+
+      await new Promise(async (resolve, reject) => {
+          if (!amqpCacoon) {
+            return reject(
+              new Error('Some how amqpCacoon is null. This should not happen')
+            );
+          }
+
+          let resolved = false;
+          await amqpCacoon.registerConsumer(
+            config.messageBus.testQueue,
+            async (channel: ChannelWrapper, msg: ConsumeMessage) => {
+              try {
+                channel.ack(msg);
+                expect(msg.content.toString(), 'Wrong message received').to.equal(
+                  'TestString'
+                );
+                if (!resolved) {
+                  resolved = true;
+                  resolve();
+                }
+              } catch (e) {
+                reject(e);
+              }
+            }
+          );
+
+          // Can we publish before registering consumer?
+          await amqpCacoon.publish(
+            '',
+            config.messageBus.testQueue,
+            Buffer.from('TestString')
+          );
+
+          setTimeout(() => {
+            if (!resolved) {
+              reject(new Error('Message rx: Timed out'));
+              resolved = true;
+            }
+          }, 200);
+        }
+      );
+
+      // Add short delay before closing connection
+      // For some reason, closing the channel immediately causes issues
+      const delay = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+
+      await delay(1000).then(async () => {
+        if (amqpCacoon) {
+          await amqpCacoon.close();
+        }
+      });
+
+    } catch (e) {
+      if (amqpCacoon) await amqpCacoon.close();
+      throw e;
+    }
+  });
+
+  // For now (until we decide to mock rmq, this is for manual testing)
+  // Start and stop rabbit mq to verify that messages sent when
+  // connection is down are received on reconnect
+  it.skip('resends messages after disconnect', async () => {
+    let amqpCacoon: AmqpCacoon | null = null;
+
+    try {
+      amqpCacoonConfig.onBrokerConnect = () => {
+        console.log("Connection made!")
+      }
+
+      amqpCacoonConfig.onBrokerDisconnect = () => {
+        console.log("Connection lost!")
+      }
+
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+
+      await new Promise(async (resolve, reject) => {
+          if (!amqpCacoon) {
+            return reject(
+              new Error('Some how amqpCacoon is null. This should not happen')
+            );
+          }
+
+          let resolved = false;
+          let numConsumed = 0;
+          let numSent = 0;
+          let numToSend = 6;
+          await amqpCacoon.registerConsumer(
+            config.messageBus.testQueue,
+            async (channel: ChannelWrapper, msg: ConsumeMessage) => {
+              try {
+                channel.ack(msg);
+                console.log("Received message: ", msg.content.toString());
+                numConsumed++;
+                if (numToSend == numConsumed) {
+                  resolved = true;
+                  resolve();
+                }
+              } catch (e) {
+                reject(e);
+              }
+            }
+          );
+
+
+          setInterval(async () => {
+            if (amqpCacoon) {
+              if (numSent < numToSend) {
+                let msgContent = "Test message " + numSent;
+                console.log("Sending message: ", msgContent);
+
+                // Do not await successful receipt, event if connection is lost
+                // Keep sending while connection is down
+                amqpCacoon.publish(
+                  '',
+                  config.messageBus.testQueue,
+                  Buffer.from(msgContent)
+                );
+                numSent++;
+
+              } else {
+                // Stop calling this function
+                console.log("I guess we sent them all");
+              }
+            }
+
+          }, 10000);
+
+          setTimeout(() => {
+            if (!resolved) {
+              reject(new Error('Message rx: Timed out'));
+              resolved = true;
+            }
+          }, 100000);
+        }
+      );
+
+      // Add short delay before closing connection
+      // For some reason, closing the channel immediately causes issues
+      const delay = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+
+      await delay(1000).then(async () => {
+        if (amqpCacoon) {
+          await amqpCacoon.close();
+        }
+      });
+
+    } catch (e) {
+      if (amqpCacoon) await amqpCacoon.close();
+      throw e;
+    }
+  }).timeout(100000);
+
+  // Skipping this test for now, until we confirm / deny that we will try to listen to drain event
+  it.skip('publish - Drain timeout path', async () => {
+    let amqpCacoon: AmqpCacoon | null = null;
+    try {
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+
+      let channelStubs = {
+        publish: simple.stub().returnWith(false),
+        once: simple.stub(),
+      };
+      let override: any = amqpCacoon;
+      override.pubChannel = channelStubs;
+
+      // Test drain with timeout
+      try {
+        await amqpCacoon.publish(
+          '',
+          config.messageBus.testQueue,
+          Buffer.from('TestString')
+        );
+        throw new Error(
+          'Failed! amqpCacoon.publish should have been rejected!'
+        );
+      } catch (e) {
+        console.log(e);
+        expect(e.message).to.include('Timeout');
+      }
+
+      // Test drain without timeout
+      channelStubs.once.callbackWith(null);
+      await amqpCacoon.publish(
+        '',
+        config.messageBus.testQueue,
+        Buffer.from('TestString')
+      );
+
+      expect(channelStubs.publish.called, 'channel.publish was not called').to
+        .be.true;
+      expect(channelStubs.once.called, 'channel.once was not called').to.be
+        .true;
+    } catch (e) {
+      throw e;
+    }
+  });
+
+  it('registerConsumerBatch - Batches on time limit', async () => {
+    try {
+      let messageStrings = ['Test1', 'Test2'];
+      await testBatchConsume(messageStrings, messageStrings, {
+        batching: {maxTimeMs: 200},
+      });
+    } catch (e) {
+      throw e;
+    }
+  });
+
+  it('registerConsumerBatch - Batches on message size', async () => {
+    try {
+      // Doesn't get messages after going over size
+      await testBatchConsume(['Test1', 'Test2', 'Test3'], ['Test1', 'Test2'], {
+        batching: {maxTimeMs: 0, maxSizeBytes: 6},
+      });
+
+      // Works on large messages
+      let largeMessage = '';
+      for (let i = 0; i < 1024 * 1024; i++) {
+        largeMessage += 'a';
+      }
+      await testBatchConsume(
+        [largeMessage, largeMessage, largeMessage],
+        [largeMessage, largeMessage],
+        {
+          batching: {maxTimeMs: 1000, maxSizeBytes: 1024 * 1024 * 2},
+        }
+      );
+    } catch (e) {
+      throw e;
+    }
+  });
+
+  /**
+   * testBatchConsume
+   * This is used by other tests to test the registerConsumerBatch function
+   *
+   * Does this by
+   * 1. Setup amqp
+   * 2. Purge queue to make sure other tests are not messing us up
+   * 3. Publish all txMessageStrings to bus
+   * 4. Register callback with registerConsumerBatch
+   * 5. Within callback ack all if messages come through.
+   * 6. Test message length using rxMessageStrings.length
+   * 7. Test message buffer size
+   * 8. Compare rxMessageStrings values to incomming messages
+   * 9. Reject if we timeout
+   */
+  async function testBatchConsume(
+    txMessageStrings: Array<string>,
+    rxMessageStrings: Array<string>,
+    consumerOptions: ConsumerBatchOptions
+  ) {
+    let amqpCacoon: AmqpCacoon | null = null;
+    try {
+      // 1. Setup amqp
+      amqpCacoon = new AmqpCacoon(amqpCacoonConfig);
+      let channel: ChannelWrapper | null = await amqpCacoon.getPublishChannel();
+      // if (channel) await channel.assertQueue(config.messageBus.testQueue);
+      // 2. Purge queue to make sure other tests are not messing us up
+      // await channel.purgeQueue(config.messageBus.testQueue);
+
+      await new Promise(async (resolve, reject) => {
+        if (!amqpCacoon) {
+          return reject(
+            new Error('Some how amqpCacoon is null. This should not happen')
+          );
+        }
+        // 3. Publish all txMessageStrings to bus
+        for (let msg of txMessageStrings) {
+          await amqpCacoon.publish(
+            '',
+            config.messageBus.testQueue,
+            Buffer.from(msg)
+          );
+        }
+
+        let resolved = false;
+        // 4. Register callback with registerConsumerBatch
+        amqpCacoon.registerConsumerBatch(
+          config.messageBus.testQueue,
+          async (channel: ChannelWrapper, batch: ConsumeBatchMessages) => {
+            try {
+              // 5. Within callback ack all if messages come through.
+              batch.ackAll();
+              // 6. Test message length using rxMessageStrings.length
+              expect(batch.messages).to.have.length;
+              expect(batch.messages.length).to.equal(rxMessageStrings.length);
+              // 7. Test message buffer size
+              expect(batch.totalSizeInBytes).to.equal(
+                rxMessageStrings // Sum length of all string in array
+                  .map((m) => m.length)
+                  .reduce((note, value) => note + value, 0)
+              );
+
+              // 8. Compare rxMessageStrings values to incomming messages
+              for (let msg of batch.messages) {
+                expect(
+                  rxMessageStrings,
+                  'Message String did not match'
+                ).to.includes(msg.content.toString());
+              }
+
+              if (!resolved) {
+                resolve();
+                resolved = true;
+              }
+            } catch (e) {
+              if (!resolved) {
+                reject(e);
+              }
+            }
+          },
+          consumerOptions
+        );
+        // Set timer incase we timeout
+        setTimeout(() => {
+          if (!resolved) {
+            // 9. Reject if we timeout
+            reject(new Error('Message rx: Timed out'));
+            resolved = true;
+          }
+        }, (consumerOptions?.batching?.maxTimeMs || 0) + 100);
+      });
+      if (amqpCacoon) amqpCacoon.close();
+    } catch (e) {
+      if (amqpCacoon) amqpCacoon.close();
+      throw e;
+    }
+  }
 });


### PR DESCRIPTION
Replaces the underlying amqplib library with [node-amqp-connection-manager](https://github.com/jwalton/node-amqp-connection-manager), which provides support for network reconnects and handles re-sending of any messages sent while the network is down. 

Note that node-amqp-connection-manager currently has a reported bug and does not currently handle drain events. While it guarantees receipt of all published messages, it does not resend failed messages when a drain emit is fired. This would ideally be fixed in the library and allow us to resend on drain like we did previously (instead of on a fixed time interval). See https://github.com/jwalton/node-amqp-connection-manager/issues/129

Closes #11 