### PR TITLE
Fixes an issue with CONNECT and DISCONNECT events.

### DIFF
--- a/examples/src/example-amqp-consumer-batch.js
+++ b/examples/src/example-amqp-consumer-batch.js
@@ -48,6 +48,16 @@ let amqpCacoon = new AmqpCacoon({
   providers: {
     logger: logger,
   },
+  onBrokerConnect: async (connection, url) => {
+    // This is an example "Connect" event fired off by AMQP Connection Manager
+    logger.debug(
+      `Connected to broker: "${amqpConfig.host}" on port ${amqpConfig.port} over "${amqpConfig.protocol}".`
+    );
+  },
+  onBrokerDisconnect: async (err) => {
+    // This is an example "Disconnect" event fired off by AMQP Connection Manager
+    logger.error(`Broker disconnected with error "${err.message}"`);
+  },
   // Important - onChannelConnect will ensure a certain configuration exists in RMQ.
   // This might not be needed in environments where RMQ is setup by some other process!
   onChannelConnect: async (channel) => {

--- a/examples/src/example-amqp-consumer.js
+++ b/examples/src/example-amqp-consumer.js
@@ -46,6 +46,16 @@ let amqpCacoon = new AmqpCacoon({
   providers: {
     logger: logger,
   },
+  onBrokerConnect: async (connection, url) => {
+    // This is an example "Connect" event fired off by AMQP Connection Manager
+    logger.debug(
+      `Connected to broker: "${amqpConfig.host}" on port ${amqpConfig.port} over "${amqpConfig.protocol}".`
+    );
+  },
+  onBrokerDisconnect: async (err) => {
+    // This is an example "Disconnect" event fired off by AMQP Connection Manager
+    logger.error(`Broker disconnected with error "${err.message}"`);
+  },
   // Important - onChannelConnect will ensure a certain configuration exists in RMQ.
   // This might not be needed in environments where RMQ is setup by some other process!
   onChannelConnect: async (channel) => {

--- a/examples/src/example-amqp-publish.js
+++ b/examples/src/example-amqp-publish.js
@@ -47,6 +47,16 @@ let amqpCacoon = new AmqpCacoon({
   providers: {
     logger: logger,
   },
+  onBrokerConnect: async (connection, url) => {
+    // This is an example "Connect" event fired off by AMQP Connection Manager
+    logger.debug(
+      `Connected to broker: "${amqpConfig.host}" on port ${amqpConfig.port} over "${amqpConfig.protocol}".`
+    );
+  },
+  onBrokerDisconnect: async (err) => {
+    // This is an example "Disconnect" event fired off by AMQP Connection Manager
+    logger.error(`Broker disconnected with error "${err.message}"`);
+  },
   // Important - onChannelConnect will ensure a certain configuration exists in RMQ.
   // This might not be needed in environments where RMQ is setup by some other process!
   onChannelConnect: async (channel) => {
@@ -92,11 +102,7 @@ async function main() {
   const messageAsBuffer = Buffer.from(`Hi. Today is ${new Date().toString()}`);
 
   // Publish
-  await amqpCacoon.publish(
-    amqpConfig.exampleExchange,
-    '',
-    messageAsBuffer
-  );
+  await amqpCacoon.publish(amqpConfig.exampleExchange, '', messageAsBuffer);
 
   // Close the connection
   amqpCacoon.close();


### PR DESCRIPTION
Fixes an issue where CONNECT and DISCONNECT events would not actually pass the event data.

- Created types for the two callbacks, and exported them.
- Wired up the new types to the options coming into AMQP Cacoon.
- Refactored the call hookups against AMQP CONN MGR to properly pass the event data.
- Updated the examples to show using this.